### PR TITLE
Adding test case: MVEL is not resolving method calls on the context object

### DIFF
--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3250,4 +3250,18 @@ public class CoreConfidenceTests extends AbstractTest {
     assertNotNull(result);
   }
 
+  public void testContextObjMethodCall() {
+      String str = "getName() == \"bob\"";
+
+      ParserConfiguration pconf = new ParserConfiguration();
+      ParserContext pctx = new ParserContext(pconf);
+      pctx.setStrongTyping(true);
+      pctx.addInput( "this", Bar.class );
+      ExecutableStatement stmt = (ExecutableStatement) MVEL.compileExpression(str, pctx);
+      Bar ctx = new Bar();
+      ctx.setName( "bob" );
+      Boolean result = (Boolean) MVEL.executeExpression( stmt, ctx );
+      assertTrue( result );
+  }
+
 }


### PR DESCRIPTION
Adding test case: MVEL is not resolving method calls on the context object. I.e.

name == "bob" -----> works for context object Person
getName() == "bob" ------> does not work for the same context object

[Error: no such identifier: getName]
[Near : {... getName() == "bob" ....}]
             ^
[Line: 1, Column: 1]
    at org.mvel2.compiler.ExpressionCompiler.verify(ExpressionCompiler.java:405)
    at org.mvel2.compiler.ExpressionCompiler._compile(ExpressionCompiler.java:283)
