### PR TITLE
Adding test for generics support bug

### DIFF
--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3349,4 +3349,40 @@ public class CoreConfidenceTests extends AbstractTest {
 
     assertFalse((Boolean) MVEL.executeExpression(s));
   }
+  
+  public static class A {
+      private Map<String,String> map;
+
+    /**
+     * @return the map
+     */
+    public Map<String, String> getMap() {
+        return map;
+    }
+
+    /**
+     * @param map the map to set
+     */
+    public void setMap( Map<String, String> map ) {
+        this.map = map;
+    }
+      
+  }
+  
+  public void testGenericMethods() {
+      String str = "Integer.parseInt( a.getMap().get(\"x\") )";
+
+      ParserConfiguration pconf = new ParserConfiguration();
+      ParserContext pctx = new ParserContext(pconf);
+      pctx.setStrongTyping(true);
+      pctx.addInput( "a", A.class );
+      ExecutableStatement stmt = (ExecutableStatement) MVEL.compileExpression(str, pctx);
+      A a = new A();
+      a.setMap( new HashMap<String,String>() );
+      a.getMap().put( "x", "10" );
+      Map<String,Object> variables = new HashMap<String, Object>();
+      variables.put( "a", a );
+      Number result = (Number) MVEL.executeExpression( stmt, null, variables );
+      assertEquals( 10,  result.intValue() );
+  }
 }


### PR DESCRIPTION
Although the class declares a method:

public Map&lt;String, String&gt; getMap()

MVEL is resolving the type of getMap().get(...) as Object instead of String, raising a compilation error when using strong typing.

Adding test case.
