### PR TITLE
Add a failing test for invocation of a varargs method

### DIFF
--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3389,5 +3389,11 @@ public class CoreConfidenceTests extends AbstractTest {
     assertFalse((Boolean) MVEL.executeExpression(s));
   }
 
+  public void testVarArgsParams() {
+    assertEquals(String.format("%010d", 123),
+      runSingleTest("a = new Object[1]; a[0] = 123; String.format(\"%010d\", a)"));
 
+    assertEquals(String.format("%010d", 123),
+      runSingleTest("String.format(\"%010d\", 123)"));
+  }
 }


### PR DESCRIPTION
MVEL seems to not work properly with Java methods having a varargs argument. In the failing test I added, String.format() works as expected if you pass to it a proper array but prints "[Error: Argument is not an array]" if you try to invoke the format() method leveraging the varargs syntax 
