### PR TITLE
[MVEL-257] IllegalStateException under heavy load

### DIFF
--- a/src/main/java/org/mvel2/ParserConfiguration.java
+++ b/src/main/java/org/mvel2/ParserConfiguration.java
@@ -283,7 +283,9 @@ public class ParserConfiguration implements Serializable {
       nonValidImports = new LinkedHashSet<String>();
     }
     else if (nonValidImports.size() > 1000) {
-      nonValidImports.iterator().remove();
+      Iterator<String> i = nonValidImports.iterator();
+      i.next();
+      i.remove();
     }
 
     nonValidImports.add(negativeHit);


### PR DESCRIPTION
As reported here http://download.oracle.com/javase/6/docs/api/java/util/Iterator.html#remove%28%29 next() should be called before any remove().

I didn't do that but my advice is to implement the nonValidImports Set with a LinkedHashMap using access-order as ordering mode http://download.oracle.com/javase/6/docs/api/java/util/LinkedHashMap.html#LinkedHashMap%28int,%20float,%20boolean%29 and overriding the removeEldestEntry method as suggested here http://download.oracle.com/javase/6/docs/api/java/util/LinkedHashMap.html#removeEldestEntry%28java.util.Map.Entry%29

Note that since HashSets are backed by an HashMap instance in each case you won't waste more memory with this implementation.

Let me know if you prefer this second solution so, if you want, I could implement it for your and change this pull request accordingly.
