### PR TITLE
avoid infinite loops when trying to access a null map

### DIFF
--- a/src/main/java/org/mvel2/PropertyAccessor.java
+++ b/src/main/java/org/mvel2/PropertyAccessor.java
@@ -219,6 +219,8 @@ public class PropertyAccessor {
         else {
           nullHandle = false;
         }
+      } else {
+        if (curr == null && cursor < end) throw new NullPointerException();
       }
 
       first = false;
@@ -254,6 +256,8 @@ public class PropertyAccessor {
         else {
           nullHandle = false;
         }
+      } else {
+        if (curr == null && cursor < end) throw new NullPointerException();
       }
 
       first = false;
@@ -745,6 +749,7 @@ public class PropertyAccessor {
     if (ctx == null) return null;
 
     int _start = ++cursor;
+
     whiteSpaceSkip();
 
     if (cursor == end || scanTo(']'))
@@ -793,6 +798,7 @@ public class PropertyAccessor {
     if (ctx == null) return null;
 
     int _start = ++cursor;
+
     whiteSpaceSkip();
 
     if (cursor == end || scanTo(']'))

--- a/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -174,7 +174,7 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
     }
 
     if (ctx == null) {
-      throw new PropertyAccessException("could not access property: " + new String(property, this.start, length) + "; parent is null: "
+      throw new PropertyAccessException("could not access property: " + new String(property, this.start, Math.min(length, property.length)) + "; parent is null: "
           + new String(expr), expr, this.start);
     }
 
@@ -350,9 +350,11 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
 
           first = false;
           if (curr != null) returnType = curr.getClass();
-          if (nullSafe && cursor < length) {
-            int os = expr[cursor] == '.' ? 1 : 0;
-            addAccessorNode(new NullSafe(expr, cursor + os, length - cursor - os, pCtx));
+          if (cursor < length) {
+            if (nullSafe) {
+              int os = expr[cursor] == '.' ? 1 : 0;
+              addAccessorNode(new NullSafe(expr, cursor + os, length - cursor - os, pCtx));
+            }
             if (curr == null) break;
           }
           staticAccess = false;
@@ -380,9 +382,11 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
 
           first = false;
           if (curr != null) returnType = curr.getClass();
-          if (nullSafe && cursor < length) {
-            int os = expr[cursor] == '.' ? 1 : 0;
-            addAccessorNode(new NullSafe(expr, cursor + os, length - cursor - os, pCtx));
+          if (cursor < length) {
+            if (nullSafe) {
+              int os = expr[cursor] == '.' ? 1 : 0;
+              addAccessorNode(new NullSafe(expr, cursor + os, length - cursor - os, pCtx));
+            }
             if (curr == null) break;
           }
           staticAccess = false;

--- a/src/test/java/org/mvel2/tests/core/PropertyAccessTests.java
+++ b/src/test/java/org/mvel2/tests/core/PropertyAccessTests.java
@@ -380,4 +380,17 @@ public class PropertyAccessTests extends AbstractTest {
     a.map = nestMap;
     assertEquals("bar", MVEL.executeExpression(s, m));
   }
+
+    public void testInfiniteLoop() {
+      A226 a = new A226();
+      Map m = Collections.singletonMap("a", a);
+      String ex = "a.map['foo']";
+
+      try {
+        MVEL.getProperty(ex, m);
+        fail("access to a null field must fail");
+      } catch (Exception e) {
+        // ignore
+      }
+    }
 }


### PR DESCRIPTION
As reported in this Drools ticket:

https://issues.jboss.org/browse/JBRULES-3196

when you try to read a value from a non initialized map, MVEL enters in an infinite loop instead of throwing an exception as expected. This pull request should fix this issue.

Note that the test I added actually enters in an infinite loop without my fix. I wanted to added a timeout that makes the test fails after a few seconds, but I couldn't because this possibility has been added in junit 4

http://junit.sourceforge.net/javadoc/org/junit/Test.html

while MVEL still uses junit 3.8
