### PR TITLE
add support for class literals when the class name is fully qualified

### DIFF
--- a/src/main/java/org/mvel2/PropertyAccessor.java
+++ b/src/main/java/org/mvel2/PropertyAccessor.java
@@ -1037,7 +1037,7 @@ public class PropertyAccessor {
             if (!meth) {
               try {
                 String test = new String(property, start, (cursor = last) - start);
-
+                if (test.endsWith(".class")) test = test.substring(0, test.length() - 6);
                 return currentThread().getContextClassLoader().loadClass(test);
               }
               catch (ClassNotFoundException e) {

--- a/src/main/java/org/mvel2/compiler/PropertyVerifier.java
+++ b/src/main/java/org/mvel2/compiler/PropertyVerifier.java
@@ -262,7 +262,7 @@ public class PropertyVerifier extends AbstractOptimizer {
         fqcn = true;
         resolvedExternally = false;
         if (tryStaticMethodRef instanceof Class) {
-          classLiteral = true;
+          classLiteral = !new String(expr, cursor - start - 6, 6).equals(".class");
           return (Class) tryStaticMethodRef;
         }
         else if (tryStaticMethodRef instanceof Field) {

--- a/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
@@ -68,7 +68,7 @@ public class AbstractOptimizer extends AbstractParser {
             if (!meth) {
               try {
                 String test = new String(expr, start, (cursor = last) - start);
-
+                if (test.endsWith(".class")) test = test.substring(0, test.length() - 6);
                 return Class.forName(test, true, pCtx != null ?
                     pCtx.getParserConfiguration().getClassLoader() : currentThread().getContextClassLoader());
               }

--- a/src/test/java/org/mvel2/tests/core/UnsupportedFeaturesTests.java
+++ b/src/test/java/org/mvel2/tests/core/UnsupportedFeaturesTests.java
@@ -21,8 +21,12 @@ public class UnsupportedFeaturesTests extends TestCase {
     OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
 
     assertEquals(String.class, MVEL.eval("String.class"));
+    assertEquals(String.class, MVEL.eval("java.lang.String.class"));
+    assertEquals(java.util.ArrayList.class, MVEL.eval("java.util.ArrayList.class"));
 
     assertEquals(String.class, MVEL.analyze("String.class", ParserContext.create()));
+    assertEquals(String.class, MVEL.analyze("java.lang.String.class", ParserContext.create()));
+    assertEquals(java.util.ArrayList.class, MVEL.analyze("java.util.ArrayList.class", ParserContext.create()));
 
     MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS = false;
   }


### PR DESCRIPTION
Implementation for missing feature pointed out by etirelli in https://github.com/mvel/mvel/pull/19
