### PR TITLE
making fields starting with an uppercase working

### DIFF
--- a/src/main/java/org/mvel2/ParserContext.java
+++ b/src/main/java/org/mvel2/ParserContext.java
@@ -453,7 +453,10 @@ public class ParserContext implements Serializable {
             if (m.getName().startsWith("get")
                     || (m.getName().startsWith("is")
                     && (m.getReturnType().equals(boolean.class) || m.getReturnType().equals(Boolean.class)))) {
-              scope.add(ReflectionUtil.getPropertyFromAccessor(m.getName()));
+              String propertyName = ReflectionUtil.getPropertyFromAccessor(m.getName());
+              scope.add(propertyName);
+              propertyName = propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+              scope.add(propertyName);
             } else {
               scope.add(m.getName());
             }

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3462,4 +3462,32 @@ public class CoreConfidenceTests extends AbstractTest {
     assertEquals(String.format("%010d -- %010d", 123, 456),
       runSingleTest("a = 123; b = 456; String.format(\"%010d -- %010d\", a, b)"));
   }
+
+  public static class Bean1 {
+    private String Field1;
+    private String FIELD2;
+
+    public String getField1() {
+      return Field1;
+    }
+    public void setField1(String Field1) {
+      this.Field1 = Field1;
+    }
+
+    public String getFIELD2() {
+      return FIELD2;
+    }
+    public void setFIELD2(String FIELD2) {
+      this.FIELD2 = FIELD2;
+    }
+  }
+
+  public void testUppercaseField() {
+    String ex = "Field1 == \"foo\" || FIELD2 == \"bar\"";
+    final ParserContext parserContext2 = new ParserContext();
+    parserContext2.setStrictTypeEnforcement( true );
+    parserContext2.setStrongTyping( true );
+    parserContext2.addInput("this", Bean1.class);
+    MVEL.analyze( ex, parserContext2 );
+  }
 }


### PR DESCRIPTION
This fixes an issue originally reported in https://issues.jboss.org/browse/JBRULES-3147

Unfortunately, from the JavaBean specification, given a method named getField() is not possible to infer if it is referred to a property named field or Field so I made it work in both cases. Moreover, still accordingly with that spec, an accessor named getFIELD() should be referred to a property named FIELD and not fIELD as it infers currently. Anyway, even for this special case, this fix makes it works with both formats.
