### PR TITLE
lookahead to avoid invalid casts

### DIFF
--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -1031,11 +1031,22 @@ public class AbstractParser implements Parser, Serializable {
                 Class cls;
                 try {
                   if (tDescr.isClass() && (cls = getClassReference(pCtx, tDescr)) != null) {
-                    st = cursor;
-                    captureToEOS();
 
-                    return lastNode = new TypeCast(expr, st, cursor - st,
-                        cls, fields, pCtx);
+                    // lookahead to check if it could be a real cast
+                    boolean isCast = false;
+                    for (int i = cursor; i < expr.length; i++) {
+                      if (expr[i] == ' ' || expr[i] == '\t') continue;
+                      isCast = isIdentifierPart(expr[i]) || expr[i] == '\'' || expr[i] == '"' || expr[i] == '(';
+                      break;
+                    }
+
+                    if (isCast) {
+                        st = cursor;
+                        captureToEOS();
+
+                        return lastNode = new TypeCast(expr, st, cursor - st,
+                            cls, fields, pCtx);
+                    }
                   }
                 }
                 catch (ClassNotFoundException e) {

--- a/src/test/java/org/mvel2/tests/core/UnsupportedFeaturesTests.java
+++ b/src/test/java/org/mvel2/tests/core/UnsupportedFeaturesTests.java
@@ -20,6 +20,18 @@ public class UnsupportedFeaturesTests extends TestCase {
 
     OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
 
+    assertEquals(String.class, MVEL.eval("String"));
+    assertEquals(String.class, MVEL.eval("java.lang.String"));
+    assertEquals(java.util.ArrayList.class, MVEL.eval("java.util.ArrayList"));
+
+    assertEquals(String.class, MVEL.eval("(String)"));
+    assertEquals(String.class, MVEL.eval("(java.lang.String)"));
+    assertEquals(java.util.ArrayList.class, MVEL.eval("(java.util.ArrayList)"));
+
+    assertEquals(String.class, MVEL.eval("(String.class)"));
+    assertEquals(String.class, MVEL.eval("(java.lang.String.class)"));
+    assertEquals(java.util.ArrayList.class, MVEL.eval("(java.util.ArrayList.class)"));
+
     assertEquals(String.class, MVEL.eval("String.class"));
     assertEquals(String.class, MVEL.eval("java.lang.String.class"));
     assertEquals(java.util.ArrayList.class, MVEL.eval("java.util.ArrayList.class"));


### PR DESCRIPTION
At the moment a class name between parenthesis is always interpreted as a cast, but this is not always the case as also demonstrated by this 2 drools issues:

https://issues.jboss.org/browse/JBRULES-2951
https://issues.jboss.org/browse/JBRULES-3134

My pull request does a small lookahead to try to disambiguate it.
