### PR TITLE
throws a NPE when the property of a null object is tried to be accessed in unsafe way

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -357,8 +357,9 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
             if (nullSafe) {
               int os = expr[cursor] == '.' ? 1 : 0;
               addAccessorNode(new NullSafe(expr, cursor + os, length - cursor - os, pCtx));
+              if (curr == null) break;
             }
-            if (curr == null) break;
+            if (curr == null) throw new NullPointerException();
           }
           staticAccess = false;
         }
@@ -389,8 +390,9 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
             if (nullSafe) {
               int os = expr[cursor] == '.' ? 1 : 0;
               addAccessorNode(new NullSafe(expr, cursor + os, length - cursor - os, pCtx));
+              if (curr == null) break;
             }
-            if (curr == null) break;
+            if (curr == null) throw new NullPointerException();
           }
           staticAccess = false;
         }


### PR DESCRIPTION
In one of my former pull request ( https://github.com/mvel/mvel/pull/20 ) I omitted to properly manage a corner case: when the property of a null object is accessed in unsafe way (without the elvis operator) it should fail with a NPE instead of ignoring it silently as it does now. I discovered this bug by trying to run the drools test suite using the latest mvel snapshot
