### PR TITLE
checks expression syntax and returns correct type

### DIFF
--- a/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
+++ b/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
@@ -287,7 +287,11 @@ public class ExpressionCompiler extends AbstractParser {
         return new CompiledExpression(finalizePayload(astBuild, secondPassOptimization, pCtx), pCtx.getSourceFile(), returnType, pCtx, literalOnly == 1);
       }
       else {
-        returnType = CompilerTools.getReturnType(astBuild);
+        try {
+          returnType = CompilerTools.getReturnType(astBuild, pCtx.isStrongTyping());
+        } catch (RuntimeException e) {
+          throw new CompileException(e.getMessage(), expr, st, e);
+        }
         return null;
       }
     }

--- a/src/main/java/org/mvel2/util/ASTBinaryTree.java
+++ b/src/main/java/org/mvel2/util/ASTBinaryTree.java
@@ -1,0 +1,122 @@
+package org.mvel2.util;
+
+import static org.mvel2.Operator.*;
+import org.mvel2.ast.ASTNode;
+import org.mvel2.ast.EndOfStatement;
+import org.mvel2.ast.OperatorNode;
+
+public class ASTBinaryTree {
+    private ASTNode root;
+    private ASTBinaryTree left;
+    private ASTBinaryTree right;
+
+    public ASTBinaryTree(ASTNode node) {
+        this.root = node;
+    }
+
+    public ASTBinaryTree append(ASTNode node) {
+        if (comparePrecedence(root, node) >= 0) {
+            ASTBinaryTree tree = new ASTBinaryTree(node);
+            tree.left = this;
+            return tree;
+        } else {
+            if (left == null) throw new RuntimeException("Missing left node");
+            if (right == null) {
+                right = new ASTBinaryTree(node);
+            } else {
+                right = right.append(node);
+            }
+            return this;
+        }
+    }
+
+    public Class<?> getReturnType(boolean strongTyping) {
+        if (!(root instanceof OperatorNode)) return root.getEgressType();
+        if (left == null || right == null) throw new RuntimeException("Malformed expression");
+        Class<?> leftType = left.getReturnType(strongTyping);
+        Class<?> rightType = right.getReturnType(strongTyping);
+        switch (((OperatorNode)root).getOperator()) {
+            case CONTAINS:
+            case SOUNDEX:
+            case INSTANCEOF:
+            case SIMILARITY:
+                return Boolean.class;
+            case ADD:
+                if (leftType.equals(String.class) || rightType.equals(String.class)) return String.class;
+            case SUB:
+            case MULT:
+            case DIV:
+            case TERNARY_ELSE:
+                if (strongTyping && !areCompatible(leftType, rightType))
+                    throw new RuntimeException("Associative operation requires compatible types. Found " + leftType + " and " + rightType);
+                return leftType;
+            case EQUAL:
+            case NEQUAL:
+            case LTHAN:
+            case LETHAN:
+            case GTHAN:
+            case GETHAN:
+                if (strongTyping && !areCompatible(leftType, rightType))
+                    throw new RuntimeException("Comparison operation requires compatible types. Found " + leftType + " and " + rightType);
+                return Boolean.class;
+            case AND:
+            case OR:
+                if (strongTyping) {
+                    if (leftType != Boolean.class && leftType != Boolean.TYPE)
+                        throw new RuntimeException("Left side of logical operation is not of type boolean. Found " + leftType);
+                    if (rightType != Boolean.class && rightType != Boolean.TYPE)
+                        throw new RuntimeException("Right side of logical operation is not of type boolean. Found " + rightType);
+                }
+                return Boolean.class;
+            case TERNARY:
+                if (strongTyping && leftType != Boolean.class && leftType != Boolean.TYPE)
+                    throw new RuntimeException("Condition of ternary operator is not of type boolean. Found " + leftType);
+                return rightType;
+        }
+        // TODO: should throw new RuntimeException("Unknown operator");
+        // it doesn't because I am afraid I am not covering all the OperatorNode types
+        return root.getEgressType();
+    }
+
+    private boolean areCompatible(Class<?> c1, Class<?> c2) {
+        if (c1.isAssignableFrom(c2) || c2.isAssignableFrom(c1)) return true;
+        if (Number.class.isAssignableFrom(c1) && Number.class.isAssignableFrom(c2)) return true;
+        if (c1.isPrimitive()) return arePrimitiveCompatible(c1, c2);
+        if (c2.isPrimitive()) return arePrimitiveCompatible(c2, c1);
+        return false;
+    }
+
+    private boolean arePrimitiveCompatible(Class<?> primitive, Class<?> boxed) {
+        if (primitive == Boolean.TYPE) return boxed == Boolean.class;
+        if (primitive == Integer.TYPE) return Number.class.isAssignableFrom(boxed);
+        if (primitive == Long.TYPE) return Number.class.isAssignableFrom(boxed);
+        if (primitive == Double.TYPE) return Number.class.isAssignableFrom(boxed);
+        if (primitive == Float.TYPE) return Number.class.isAssignableFrom(boxed);
+        if (primitive == Character.TYPE) return boxed == Character.class;
+        if (primitive == Byte.TYPE) return boxed == Byte.class;
+        if (primitive == Short.TYPE) return boxed == Short.class;
+        return false;
+    }
+
+    private int comparePrecedence(ASTNode node1, ASTNode node2) {
+        if (!(node1 instanceof OperatorNode) && !(node2 instanceof OperatorNode)) return 0;
+        if (node1 instanceof OperatorNode && node2 instanceof OperatorNode) {
+            return PTABLE[((OperatorNode)node1).getOperator()] - PTABLE[((OperatorNode)node2).getOperator()];
+        }
+        return node1 instanceof OperatorNode ? -1 : 1;
+    }
+
+    public static ASTBinaryTree buildTree(ASTIterator input) {
+        ASTIterator iter = new ASTLinkedList(input.firstNode());
+        ASTBinaryTree tree = new ASTBinaryTree(iter.nextNode());
+        while (iter.hasMoreNodes()) {
+            ASTNode node = iter.nextNode();
+            if (node instanceof EndOfStatement) {
+                if (iter.hasMoreNodes()) tree = new ASTBinaryTree(iter.nextNode());
+            } else {
+                tree = tree.append(node);
+            }
+        }
+        return tree;
+    }
+}

--- a/src/main/java/org/mvel2/util/CompilerTools.java
+++ b/src/main/java/org/mvel2/util/CompilerTools.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import static org.mvel2.Operator.PTABLE;
 import static org.mvel2.compiler.AbstractParser.getCurrentThreadParserContext;
+import static org.mvel2.util.ASTBinaryTree.buildTree;
 import static org.mvel2.util.ParseTools.__resolveType;
 import static org.mvel2.util.ParseTools.boxPrimitive;
 
@@ -328,33 +329,11 @@ public class CompilerTools {
     return (bn instanceof IntOptimized && bn2.getEgressType() != Integer.class);
   }
 
-
-  public static Class getReturnType(ASTIterator input) {
-    ASTIterator iter = new ASTLinkedList(input.firstNode());
-
+  public static Class getReturnType(ASTIterator input, boolean strongTyping) {
     ASTNode begin = input.firstNode();
-    ASTNode n;
-    while (iter.hasMoreNodes()) {
-      n = iter.nextNode();
-
-      if (n instanceof EndOfStatement) {
-        if (iter.hasMoreNodes()) {
-          begin = iter.nextNode();
-        }
-      }
-      else if (n instanceof OperatorNode) {
-        if (n.isOperator(Operator.ADD)) {
-          if (iter.hasMoreNodes()) {
-            n = iter.nextNode();
-            if (n.getEgressType() == String.class) {
-              begin = n;
-            }
-          }
-        }
-      }
-    }
-
-    return begin == null ? Object.class : begin.getEgressType();
+    if (begin == null) return Object.class;
+    if (input.size() == 1) return begin.getEgressType();
+    return buildTree(input).getReturnType(strongTyping);
   }
 
   /**

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3465,6 +3465,7 @@ public class CoreConfidenceTests extends AbstractTest {
   public static class Bean1 {
     private String Field1;
     private String FIELD2;
+    private int intField;
 
     public String getField1() {
       return Field1;
@@ -3479,6 +3480,13 @@ public class CoreConfidenceTests extends AbstractTest {
     public void setFIELD2(String FIELD2) {
       this.FIELD2 = FIELD2;
     }
+
+    public int getIntField() {
+        return intField;
+    }
+    public void setIntField(int intField) {
+        this.intField = intField;
+    }
   }
 
   public void testUppercaseField() {
@@ -3488,5 +3496,38 @@ public class CoreConfidenceTests extends AbstractTest {
     parserContext2.setStrongTyping( true );
     parserContext2.addInput("this", Bean1.class);
     MVEL.analyze( ex, parserContext2 );
+  }
+
+  public void testExpressionReturnType() {
+    assertEquals(String.class, expressionReturnType("Field1"));
+    assertEquals(String.class, expressionReturnType("Field1 + FIELD2"));
+    assertEquals(String.class, expressionReturnType("Field1 + 3"));
+    assertEquals(String.class, expressionReturnType("Field1 + 3 + FIELD2"));
+    assertEquals(Integer.class, expressionReturnType("intField"));
+    assertEquals(Integer.class, expressionReturnType("intField = 3"));
+    assertEquals(Boolean.class, expressionReturnType("intField == 3"));
+    assertEquals(Boolean.class, expressionReturnType("intField == 1 || Field1 == \"xxx\""));
+    assertEquals(Boolean.class, expressionReturnType("FIELD2 == \"yyy\" && intField == 1 + 2 * 3 || Field1 == \"xxx\""));
+  }
+
+  public void testWrongExpressions() {
+    wrongExpressionMustFail("Field1 == 3");
+    wrongExpressionMustFail("Field1 - 3");
+    wrongExpressionMustFail("intField == 3 || Field1");
+  }
+
+  private void wrongExpressionMustFail(String expr) {
+    try {
+      expressionReturnType(expr);
+      fail("wrong expression '" + expr + "' must fail");
+    } catch (Exception e) { }
+  }
+
+  private Class<?> expressionReturnType(String expr) {
+    final ParserContext parserContext = new ParserContext();
+    parserContext.setStrictTypeEnforcement( true );
+    parserContext.setStrongTyping( true );
+    parserContext.addInput("this", Bean1.class);
+    return MVEL.analyze(expr, parserContext);
   }
 }


### PR DESCRIPTION
I found that in many cases expressions syntax is not exhaustively checked. For example expression like:
stringField == 3
or even
intField == 3 || stringField
are analyzed without raising any error. Moreover the returned type of the expression is often not correct, so an expression like:
intField == 3
currently is reported to have a returned type Integer instead of Boolean as expected.
This pull request should fix these problems.
