### PR TITLE
Inner enums

### DIFF
--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3291,6 +3291,22 @@ public class CoreConfidenceTests extends AbstractTest {
     assertTrue(result);
   }
 
+  public void testFullyQualifiedEnums() {
+      String str = "System.out.println( STATIC_ENUM.FOO ); \n" +
+      		       "System.out.println( org.mvel2.tests.core.res.MyInterface.STATIC_ENUM.BAR );\n" +
+      		       "System.out.println( RoundingMode.UP );\n" +
+      		       "System.out.println( java.math.RoundingMode.DOWN );";
+
+      ParserConfiguration pconf = new ParserConfiguration();
+      ParserContext pctx = new ParserContext(pconf);
+      pctx.setStrongTyping(true);
+      pctx.addInput("this", MyInterface.class);
+      pctx.addImport( MyInterface.STATIC_ENUM.class );
+      pctx.addImport( java.math.RoundingMode.class );
+      ExecutableStatement stmt = (ExecutableStatement) MVEL.compileExpression(str, pctx);
+      
+    }
+
   public void testWithInsideBlock() {
     String str = "Foo f = new Foo(); with(f) { setBoolTest( true ) }; f.isBoolTest()";
 

--- a/src/test/java/org/mvel2/tests/core/res/MyInterface.java
+++ b/src/test/java/org/mvel2/tests/core/res/MyInterface.java
@@ -11,5 +11,10 @@ public interface MyInterface {
   public boolean isType(MY_ENUM myenum);
 
   public void setType(MY_ENUM myenum, boolean flag);
+  
+  public static enum STATIC_ENUM {
+      FOO, BAR;
+  }
+  
 }
 


### PR DESCRIPTION
It seems MVEL requires $ syntax to access inner enums. This is a problem because $ is an internal name in JVM. When writing code, programmers always use . as separators for inner classes/enums.
