### PR TITLE
Avoid RuntimeException when evaluating an expression with an unused import

### DIFF
--- a/src/main/java/org/mvel2/ast/ImportNode.java
+++ b/src/main/java/org/mvel2/ast/ImportNode.java
@@ -21,6 +21,7 @@ package org.mvel2.ast;
 import org.mvel2.CompileException;
 import org.mvel2.MVEL;
 import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.ImmutableDefaultFactory;
 import org.mvel2.util.ParseTools;
 
 import static org.mvel2.util.ParseTools.findClassImportResolverFactory;
@@ -75,14 +76,14 @@ public class ImportNode extends ASTNode {
         factory.createVariable(importClass.getSimpleName(), importClass);
         return importClass;
       }
-      else {
-        return findClassImportResolverFactory(factory).addClass(importClass);
-      }
+      return findClassImportResolverFactory(factory).addClass(importClass);
     }
-    else {
+
+    // if the factory is an ImmutableDefaultFactory it means this import is unused so we can skip it safely
+    if (!(factory instanceof ImmutableDefaultFactory)) {
       findClassImportResolverFactory(factory).addPackageImport(new String(expr, start, _offset - start));
-      return null;
     }
+    return null;
   }
 
   public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {

--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -868,20 +868,17 @@ public class ParseTools {
 
 
   public static ClassImportResolverFactory findClassImportResolverFactory(VariableResolverFactory factory) {
-    VariableResolverFactory v = factory;
-    while (v != null) {
-      if (v instanceof ClassImportResolverFactory) {
-        return (ClassImportResolverFactory) v;
-      }
-      v = v.getNextFactory();
-    }
-
     if (factory == null) {
       throw new OptimizationFailure("unable to import classes.  no variable resolver factory available.");
     }
-    else {
-      return appendFactory(factory, new ClassImportResolverFactory());
+
+    for (VariableResolverFactory v = factory; v != null; v = v.getNextFactory()) {
+      if (v instanceof ClassImportResolverFactory) {
+        return (ClassImportResolverFactory) v;
+      }
     }
+
+    return appendFactory(factory, new ClassImportResolverFactory());
   }
 
   public static Class findClass(VariableResolverFactory factory, String name, ParserContext ctx) throws ClassNotFoundException {

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -140,6 +140,21 @@ public class CoreConfidenceTests extends AbstractTest {
         maps.length);
   }
 
+  public static class MyPerson {
+      private String name;
+      public MyPerson(String name) { this.name = name; }
+      public String getName() { return name; }
+  }
+
+  public void testUnusedPackageImport() {
+    String expression =
+            "import java.util.*; " +
+            "name == \"Mario\" ";
+    Serializable compiledExpression = MVEL.compileExpression(expression);
+    boolean result = (Boolean)MVEL.executeExpression(compiledExpression, new MyPerson("Mario"));
+    assertTrue(result);
+  }
+
   public void testStaticImport() {
     assertEquals(2.0,
         test("import_static java.lang.Math.sqrt; sqrt(4)"));


### PR DESCRIPTION
When evaluating an expression llike:

import java.util.*; name == "Mario";

a RuntimeException is thrown. That's because MVEL correctly recognizes that there isn't any import actually required (the flag importInjectionRequired in the CompiledExpression is set to false) and then uses an ImmutableDefaultFactory. The problem is that, when the import token is parsed, it tries to call setNextFactory on that Immutable one, resulting in the RuntimeException mentioned above.

Note indeed that both the following expressions are evaluated correctly;

import java.util.*; new ArrayList(); name == "Mario";
import java.util.ArrayList; name == "Mario"; 
