### PR TITLE
Simple compile error on some sun compilers fix

### DIFF
--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -3744,7 +3744,7 @@ public class CoreConfidenceTests extends AbstractTest {
   }
 
   private <T> T compileAndExecuteWithStrongTyping(String expression) {
-    return compileAndExecuteWithStrongTyping(expression, new HashMap());
+    return (T) compileAndExecuteWithStrongTyping(expression, new HashMap());
   }
 
   private <T> T compileAndExecuteWithStrongTyping(String expression, Map vars) {


### PR DESCRIPTION
(type parameters of T cannot be determined;
no unique maximal instance exists for type
variable T with upper bounds T,java.lang.Object).
