### PR TITLE
MVEL-237 - Clean up ThreadLocals

### DIFF
--- a/src/main/java/org/mvel2/MVELRuntime.java
+++ b/src/main/java/org/mvel2/MVELRuntime.java
@@ -24,6 +24,7 @@ import org.mvel2.compiler.CompiledExpression;
 import org.mvel2.debug.Debugger;
 import org.mvel2.debug.DebuggerContext;
 import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.optimizers.OptimizerFactory;
 import org.mvel2.util.ErrorUtil;
 import org.mvel2.util.ExecutionStack;
 
@@ -163,6 +164,9 @@ public class MVELRuntime {
       else {
         throw e;
       }
+    }
+    finally {
+      OptimizerFactory.clearThreadAccessorOptimizer();
     }
   }
 

--- a/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
+++ b/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
@@ -101,7 +101,9 @@ public class OptimizerFactory {
       //noinspection unchecked
       AccessorOptimizer ao = accessorCompilers.get(defaultOptimizer = name);
       ao.init();
-      setThreadAccessorOptimizer(ao.getClass());
+      //clear optimizer so next call to getThreadAccessorOptimizer uses the default again, don't set thread optimizer
+      //or else static initializers setting the default will unintentionally set up ThreadLocals
+      threadOptimizer.set(null);
     }
     catch (Exception e) {
       throw new RuntimeException("unable to instantiate accessor compiler", e);


### PR DESCRIPTION
Addressing http://jira.codehaus.org/browse/MVEL-237 with a slightly different solution than the original proposed patch.

The finally catch in the MVELRuntime is from what I could tell the best way to make sure that the ThreadLocal is cleaned up at the end of the execution. I'm not sure if there are other entry points but that one seemed the most logical to me to address.

I removed setting the thread local during the setting of the default optimizer to avoid problems with static initializers (such as the one in Drools and in OptimizerFactory itself) from adding a ThreadLocal unintentionally.
