### PR TITLE
MVEL-301: avoid exponential behavior when parsing nested substatements

### DIFF
--- a/src/main/java/org/mvel2/ParserContext.java
+++ b/src/main/java/org/mvel2/ParserContext.java
@@ -22,6 +22,7 @@ import org.mvel2.ast.Function;
 import org.mvel2.ast.LineLabel;
 import org.mvel2.ast.Proto;
 import org.mvel2.compiler.AbstractParser;
+import org.mvel2.compiler.CompiledExpression;
 import org.mvel2.compiler.Parser;
 import org.mvel2.integration.Interceptor;
 import org.mvel2.util.LineMapper;
@@ -71,6 +72,8 @@ public class ParserContext implements Serializable {
   private LineLabel lastLineLabel;
 
   private transient Parser rootParser;
+  private transient Map<String, CompiledExpression> compiledExpressionCache;
+  private transient Map<String, Class> returnTypeCache;
 
   private boolean functionContext = false;
   private boolean compiled = false;
@@ -1010,6 +1013,20 @@ public class ParserContext implements Serializable {
     String[] s = new String[indexedInputs.size()];
     indexedInputs.toArray(s);
     return s;
+  }
+
+  public Map<String, CompiledExpression> getCompiledExpressionCache() {
+    if (compiledExpressionCache == null) {
+      compiledExpressionCache = new HashMap<String, CompiledExpression>();
+    }
+    return compiledExpressionCache;
+  }
+
+  public Map<String, Class> getReturnTypeCache() {
+    if (returnTypeCache == null) {
+      returnTypeCache = new HashMap<String, Class>();
+    }
+    return returnTypeCache;
   }
 
   // Introduce some new Fluent API stuff here.

--- a/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
+++ b/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
@@ -24,6 +24,7 @@ import org.mvel2.util.*;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import static org.mvel2.DataConversion.canConvert;
 import static org.mvel2.DataConversion.convert;
@@ -140,10 +141,20 @@ public class ExpressionCompiler extends AbstractParser {
         returnType = tk.getEgressType();
 
         if (tk instanceof Substatement) {
-          ExpressionCompiler subCompiler = new ExpressionCompiler(expr, tk.getStart(), tk.getOffset(), pCtx);
-          tk.setAccessor(subCompiler._compile());
-
-          returnType = subCompiler.getReturnType();
+          String key = new String(expr, tk.getStart(), tk.getOffset());
+          Map<String, CompiledExpression> cec = pCtx.getCompiledExpressionCache();
+          Map<String, Class> rtc = pCtx.getReturnTypeCache();
+          CompiledExpression compiled = cec.get(key);
+          Class rt = rtc.get(key);
+          if (compiled == null) {
+            ExpressionCompiler subCompiler = new ExpressionCompiler(expr, tk.getStart(), tk.getOffset(), pCtx);
+            compiled = subCompiler._compile();
+            rt = subCompiler.getReturnType();
+            cec.put(key, compiled);
+            rtc.put(key, rt);
+          }
+          tk.setAccessor(compiled);
+          returnType = rt;
         }
 
         /**

--- a/src/test/java/org/mvel2/tests/perftests/NestedSubstatementTests.java
+++ b/src/test/java/org/mvel2/tests/perftests/NestedSubstatementTests.java
@@ -1,0 +1,38 @@
+package org.mvel2.tests.perftests;
+
+import junit.framework.TestCase;
+
+import org.mvel2.MVEL;
+
+public class NestedSubstatementTests extends TestCase {
+
+  public static final int MAX = 25;
+
+  public void testBinary() {
+    for (int n = 1; n < MAX; n++) {
+      // long t = System.currentTimeMillis();
+      String expr = "e";
+      for (int i = n; i > 0; i--) {
+        expr = String.format("t%d && (%s)", i, expr);
+      }
+      // System.out.println(expr);
+      MVEL.compileExpression(expr);
+      // long d = System.currentTimeMillis() - t;
+      // System.out.println(String.format("n=%d, t=%dms", n, d));
+    }
+  }
+
+  public void testTernary() {
+    for (int n = 1; n < MAX; n++) {
+      // long t = System.currentTimeMillis();
+      String expr = "e";
+      for (int i = n; i > 0; i--) {
+        expr = String.format("t%d ? r%d : (%s)", i, i, expr);
+      }
+      // System.out.println(expr);
+      MVEL.compileExpression(expr);
+      // long d = System.currentTimeMillis() - t;
+      // System.out.println(String.format("n=%d, t=%dms", n, d));
+    }
+  }
+}


### PR DESCRIPTION
Some expressions with nested substatements are parsed in a time exponential with respect to the number of substatements. Examples:
(A && (B && (C && (D && (E && F)))))
(A ? B : (C ? D : (E ? F : (G ? H : (I ? J : K)))))
(Add more levels to get actual failures, for instance here at around 18 levels it starts to get into tens of seconds time.)
The culprit seems to be repeated recursive calls to org.mvel2.compiler.ExpressionCompiler._compile.
