### PR TITLE
Avoid infinite loop in CompileException

### DIFF
--- a/src/main/java/org/mvel2/CompileException.java
+++ b/src/main/java/org/mvel2/CompileException.java
@@ -126,7 +126,7 @@ public class CompileException extends RuntimeException {
     int lastCr;
 
     try {
-      cs = copyValueOf(expr, start, end - start);
+      cs = copyValueOf(expr, start, end - start).trim();
     }
     catch (StringIndexOutOfBoundsException e) {
       throw e;

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -1,7 +1,6 @@
 package org.mvel2.tests.core;
 
 import junit.framework.TestCase;
-import org.junit.Ignore;
 import org.mvel2.*;
 import org.mvel2.ast.ASTNode;
 import org.mvel2.compiler.CompiledExpression;
@@ -922,6 +921,17 @@ public class CoreConfidenceTests extends AbstractTest {
         Drools.class);
 
     compiler.compile(context);
+  }
+
+  public void testCompilerExceptionFormatting() throws Exception {
+
+    try {
+      Object value = test("\n2x * 3\n");
+      fail("Invalid expression should fail");
+    } catch (Exception e) {
+      // Invalid expression should fail to compile
+    }
+
   }
 
   /**


### PR DESCRIPTION
CompileException#showCodeNearError gets into an infinite loop when there is a compile error on an expression that starts with a newline. This patch simply calls String#trim on the expression string before searching for the exact piece of code to use as the error message, as well as adding a test that will trigger the infinite loop if the fix is not in place.