### PR TITLE
Set version to 2.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.mvel</groupId>
     <artifactId>mvel2</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.0.Final</version>
+    <version>2.3.0-SNAPSHOT</version>
 
     <name>mvel</name>
     <url>http://mvel.codehaus.org/</url>


### PR DESCRIPTION
The version in the pom is still 2.2.0.Final, which means that running a "mvn clean install" will overwrite a released artifact in the local repository. This patch simply updates the version in the root pom to 2.3.0-SNAPSHOT to avoid this issue.