### PR TITLE
IterationLimiter - Limit the size of iterations in a loop

### DIFF
--- a/src/main/java/org/mvel2/ParserContext.java
+++ b/src/main/java/org/mvel2/ParserContext.java
@@ -90,6 +90,8 @@ public class ParserContext implements Serializable {
   private boolean executableCodeReached = false;
   private boolean indexAllocation = false;
   protected boolean variablesEscape = false;
+  
+  private Integer maxLoopIterationsBeforeExit;
 
   public ParserContext() {
     parserConfiguration = new ParserConfiguration();
@@ -1085,4 +1087,16 @@ public class ParserContext implements Serializable {
 
     return this;
   }
+
+  public Integer getMaxLoopIterationsBeforeExit() {
+	return maxLoopIterationsBeforeExit;
+  }
+
+  public void setMaxLoopIterationsBeforeExit(Integer maxLoopIterationsBeforeExit) {
+	this.maxLoopIterationsBeforeExit = maxLoopIterationsBeforeExit;
+  }
+  
+  
+
+
 }

--- a/src/main/java/org/mvel2/ast/DoUntilNode.java
+++ b/src/main/java/org/mvel2/ast/DoUntilNode.java
@@ -22,6 +22,7 @@ import org.mvel2.ParserContext;
 import org.mvel2.compiler.ExecutableStatement;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.sh.IterationLimiter;
 
 import java.util.HashMap;
 
@@ -58,8 +59,10 @@ public class DoUntilNode extends BlockNode {
   public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
     VariableResolverFactory lc = new MapVariableResolverFactory(new HashMap(0), factory);
 
+    IterationLimiter iterationLimiter = new IterationLimiter(ctx);
     do {
-      compiledBlock.getValue(ctx, thisValue, lc);
+    	 iterationLimiter.increment();
+    	 compiledBlock.getValue(ctx, thisValue, lc);
     }
     while (!(Boolean) condition.getValue(ctx, thisValue, lc));
 
@@ -69,8 +72,10 @@ public class DoUntilNode extends BlockNode {
   public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
     VariableResolverFactory lc = new MapVariableResolverFactory(new HashMap(0), factory);
 
+    IterationLimiter iterationLimiter = new IterationLimiter(ctx);
     do {
-      compiledBlock.getValue(ctx, thisValue, lc);
+    	iterationLimiter.increment();
+    	compiledBlock.getValue(ctx, thisValue, lc);
     }
     while (!(Boolean) condition.getValue(ctx, thisValue, lc));
 

--- a/src/main/java/org/mvel2/ast/UntilNode.java
+++ b/src/main/java/org/mvel2/ast/UntilNode.java
@@ -22,6 +22,7 @@ import org.mvel2.ParserContext;
 import org.mvel2.compiler.ExecutableStatement;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.sh.IterationLimiter;
 
 import java.util.HashMap;
 
@@ -54,8 +55,10 @@ public class UntilNode extends BlockNode {
 
   public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
     VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap(0), factory);
+    IterationLimiter iterationLimiter = new IterationLimiter(ctx);
     while (!(Boolean) condition.getValue(ctx, thisValue, factory)) {
-      compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        iterationLimiter.increment();
+        compiledBlock.getValue(ctx, thisValue, ctxFactory);
     }
 
     return null;
@@ -64,8 +67,10 @@ public class UntilNode extends BlockNode {
   public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
     VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap(0), factory);
 
+    IterationLimiter iterationLimiter = new IterationLimiter(ctx);
     while (!(Boolean) condition.getValue(ctx, thisValue, factory)) {
-      compiledBlock.getValue(ctx, thisValue, ctxFactory);
+    	iterationLimiter.increment();
+    	compiledBlock.getValue(ctx, thisValue, ctxFactory);
     }
     return null;
   }

--- a/src/main/java/org/mvel2/ast/WhileNode.java
+++ b/src/main/java/org/mvel2/ast/WhileNode.java
@@ -22,6 +22,7 @@ import org.mvel2.ParserContext;
 import org.mvel2.compiler.ExecutableStatement;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.MapVariableResolverFactory;
+import org.mvel2.sh.IterationLimiter;
 
 import java.util.HashMap;
 
@@ -50,12 +51,15 @@ public class WhileNode extends BlockNode {
       pCtx.popVariableScope();
 
     }
+  
   }
 
   public Object getReducedValueAccelerated(Object ctx, Object thisValue, VariableResolverFactory factory) {
     VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap<String, Object>(), factory);
+    IterationLimiter iterationLimiter = new IterationLimiter(ctx);
     while ((Boolean) condition.getValue(ctx, thisValue, factory)) {
-      compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        iterationLimiter.increment();
+        compiledBlock.getValue(ctx, thisValue, ctxFactory);
     }
 
     return null;
@@ -64,8 +68,10 @@ public class WhileNode extends BlockNode {
   public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
     VariableResolverFactory ctxFactory = new MapVariableResolverFactory(new HashMap<String, Object>(), factory);
 
+    IterationLimiter iterationLimiter = new IterationLimiter(ctx);
     while ((Boolean) condition.getValue(ctx, thisValue, factory)) {
-      compiledBlock.getValue(ctx, thisValue, ctxFactory);
+        iterationLimiter.increment();
+        compiledBlock.getValue(ctx, thisValue, ctxFactory);
     }
     return null;
   }

--- a/src/main/java/org/mvel2/sh/IterationLimiter.java
+++ b/src/main/java/org/mvel2/sh/IterationLimiter.java
@@ -1,0 +1,32 @@
+package org.mvel2.sh;
+
+import org.mvel2.ParserContext;
+
+import com.sun.org.apache.xalan.internal.xsltc.compiler.Parser;
+
+public class IterationLimiter {
+
+	private Integer maxIterations;
+	private int iterations = 0; 
+	 
+	public IterationLimiter( Object pCtx){
+	    
+	    if(pCtx != null &&  pCtx instanceof ParserContext){
+	    	maxIterations = ((ParserContext)pCtx).getMaxLoopIterationsBeforeExit();
+	    }
+	    this.reset();
+	}
+	
+	public void reset(){
+		this.iterations = 0;
+	}
+	
+	public void increment(){
+		
+		this.iterations++;
+		if(maxIterations != null && iterations > maxIterations){
+			throw new RuntimeException("Loop Iterations Count Exceeded");
+		}
+	}
+	
+}

--- a/src/test/java/org/mvel2/tests/core/MaxIterationsTest.java
+++ b/src/test/java/org/mvel2/tests/core/MaxIterationsTest.java
@@ -1,0 +1,120 @@
+package org.mvel2.tests.core;
+
+import static org.mvel2.MVEL.executeExpression;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mvel2.ParserContext;
+import org.mvel2.compiler.CompiledExpression;
+import org.mvel2.compiler.ExpressionCompiler;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+public class MaxIterationsTest extends AbstractTest {
+
+	
+	public void testInfiniteWhile(){
+		
+		ExpressionCompiler compiler = new ExpressionCompiler("while(true){}");
+		ParserContext ctx = new ParserContext();
+		ctx.setMaxLoopIterationsBeforeExit(50);
+		CompiledExpression ce = compiler.compile();
+		
+		try{
+			executeExpression(ce,ctx);
+		}catch(RuntimeException ex){
+			assertEquals(ex.getMessage(), "Loop Iterations Count Exceeded");
+		}
+	}
+	
+	public void testInfiniteUntil(){
+		
+		ExpressionCompiler compiler = new ExpressionCompiler("until(false){}");
+		ParserContext ctx = new ParserContext();
+		ctx.setMaxLoopIterationsBeforeExit(50);
+		CompiledExpression ce = compiler.compile(ctx);
+		
+		try{
+			executeExpression(ce,ctx);
+		}catch(RuntimeException ex){
+			assertEquals(ex.getMessage(), "Loop Iterations Count Exceeded");
+		}
+	}	
+	
+	public void testInfiniteDoUntil(){
+		
+		ExpressionCompiler compiler = new ExpressionCompiler("do{} until(false);");
+		ParserContext ctx = new ParserContext();
+		ctx.setMaxLoopIterationsBeforeExit(50);
+		CompiledExpression ce = compiler.compile(ctx);
+		
+		try{
+			executeExpression(ce,ctx);
+		}catch(RuntimeException ex){
+			assertEquals(ex.getMessage(), "Loop Iterations Count Exceeded");
+		}
+	}	
+	
+	public void testInfiniteDoWhile(){
+		
+		ExpressionCompiler compiler = new ExpressionCompiler("do{} while(true);");
+		ParserContext ctx = new ParserContext();
+		ctx.setMaxLoopIterationsBeforeExit(50);
+		CompiledExpression ce = compiler.compile(ctx);
+		
+		try{
+			executeExpression(ce,ctx);
+		}catch(RuntimeException ex){
+			assertEquals(ex.getMessage(), "Loop Iterations Count Exceeded");
+		}
+	}	
+	
+	public void testMaximumRange(){
+		
+	
+		Map<String, Object> vars = new HashMap<String, Object>();
+		VariableResolverFactory factory = new MapVariableResolverFactory(vars);
+		
+		
+		ExpressionCompiler compiler = new ExpressionCompiler("idx = 0; while(idx < 50) { idx ++}; return idx;");
+		ParserContext ctx = new ParserContext();
+		ctx.setMaxLoopIterationsBeforeExit(50);
+		CompiledExpression ce = compiler.compile();
+		
+		Number result = (Number) executeExpression(ce,ctx,factory);
+		assertEquals(result.intValue(), 50);
+	}		
+	
+	public void testLessThanMaximumRange(){
+		
+		
+		Map<String, Object> vars = new HashMap<String, Object>();
+		VariableResolverFactory factory = new MapVariableResolverFactory(vars);
+		
+		ExpressionCompiler compiler = new ExpressionCompiler("idx = 0; while(idx < 30) { idx ++}; return idx;");
+		ParserContext ctx = new ParserContext();
+		ctx.setMaxLoopIterationsBeforeExit(50);
+		CompiledExpression ce = compiler.compile();
+		
+		Number result = (Number) executeExpression(ce,ctx,factory);
+		assertEquals(result.intValue(), 30);
+	}	
+	
+	public void testMoreThanMaximumRange(){
+			
+		Map<String, Object> vars = new HashMap<String, Object>();
+		VariableResolverFactory factory = new MapVariableResolverFactory(vars);
+		
+		ExpressionCompiler compiler = new ExpressionCompiler("idx = 0; while(idx < 60) { idx ++}; return idx;");
+		ParserContext ctx = new ParserContext();
+		ctx.setMaxLoopIterationsBeforeExit(50);
+		CompiledExpression ce = compiler.compile();
+		
+		try{
+			executeExpression(ce,ctx,factory);
+		}catch(RuntimeException ex){
+			assertEquals(ex.getMessage(), "Loop Iterations Count Exceeded");
+		}
+	}	
+}


### PR DESCRIPTION
This is in order to avoid situations where users create a long/infinite loop.
By setting the parserContext we can limit those iterations on while/do blocks.
