### PR TITLE
[DROOLS-729] - accept mvel.java.version override for java.version system property

### DIFF
--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -82,6 +82,7 @@ import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.util.ErrorUtil;
 import org.mvel2.util.ExecutionStack;
 import org.mvel2.util.FunctionParser;
+import org.mvel2.util.PropertyTools;
 import org.mvel2.util.ProtoParser;
 
 import java.io.Serializable;
@@ -219,7 +220,7 @@ public class AbstractParser implements Parser, Serializable {
 
       CLASS_LITERALS.put("Array", java.lang.reflect.Array.class);
 
-      if (parseDouble(getProperty("java.version").substring(0, 3)) >= 1.5) {
+      if (parseDouble(PropertyTools.getJavaVersion().substring(0, 3)) >= 1.5) {
         try {
           CLASS_LITERALS.put("StringBuilder", currentThread().getContextClassLoader().loadClass("java.lang.StringBuilder"));
         }

--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -104,7 +104,7 @@ public class ASMAccessorOptimizer extends AbstractOptimizer implements AccessorO
   private static final int OPCODES_VERSION;
 
   static {
-    final String javaVersion = getProperty("java.version");
+    final String javaVersion = PropertyTools.getJavaVersion();
     if (javaVersion.startsWith("1.4"))
       OPCODES_VERSION = Opcodes.V1_4;
     else if (javaVersion.startsWith("1.5"))

--- a/src/main/java/org/mvel2/sh/ShellSession.java
+++ b/src/main/java/org/mvel2/sh/ShellSession.java
@@ -26,6 +26,7 @@ import org.mvel2.sh.command.basic.BasicCommandSet;
 import org.mvel2.sh.command.file.FileCommandSet;
 import org.mvel2.templates.TemplateRuntime;
 import org.mvel2.util.StringAppender;
+import org.mvel2.util.PropertyTools;
 
 import java.io.*;
 import java.util.*;
@@ -78,7 +79,7 @@ public class ShellSession {
     env.put(PROMPT_VAR, DefaultEnvironment.PROMPT);
     env.put("$OS_NAME", getProperty("os.name"));
     env.put("$OS_VERSION", getProperty("os.version"));
-    env.put("$JAVA_VERSION", getProperty("java.version"));
+    env.put("$JAVA_VERSION", PropertyTools.getJavaVersion());
     env.put("$CWD", new File(".").getAbsolutePath());
     env.put("$COMMAND_PASSTRU", "false");
     env.put("$PRINTOUTPUT", "true");

--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -35,6 +35,7 @@ import org.mvel2.compiler.ExpressionCompiler;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.ClassImportResolverFactory;
 import org.mvel2.math.MathProcessor;
+import org.mvel2.util.PropertyTools;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -65,6 +66,7 @@ import static java.lang.Class.forName;
 import static java.lang.Double.parseDouble;
 import static java.lang.String.valueOf;
 import static java.lang.System.arraycopy;
+import static java.lang.System.getProperty;
 import static java.lang.Thread.currentThread;
 import static java.nio.ByteBuffer.allocateDirect;
 import static org.mvel2.DataConversion.canConvert;
@@ -81,7 +83,7 @@ public class ParseTools {
 
   static {
     try {
-      double version = parseDouble(System.getProperty("java.version").substring(0, 3));
+      double version = parseDouble(PropertyTools.getJavaVersion().substring(0, 3));
       if (version < 1.5) {
         throw new RuntimeException("unsupported java version: " + version);
       }

--- a/src/main/java/org/mvel2/util/PropertyTools.java
+++ b/src/main/java/org/mvel2/util/PropertyTools.java
@@ -203,4 +203,16 @@ public class PropertyTools {
   public static boolean isAssignable(Class to, Class from) {
     return (to.isPrimitive() ? boxPrimitive(to) : to).isAssignableFrom(from.isPrimitive() ? boxPrimitive(from) : from);
   }
+
+  /**
+   * Get the JVM version
+   * @return first <code>mvel.java.version</code>, then <code>java.version</code>
+   * @see System.getProperty("mvel.java.version");
+   * @see System.getProperty("java.version");
+   */
+  public static String getJavaVersion() {
+    return System.getProperty("mvel.java.version")!=null ?
+            System.getProperty("mvel.java.version") :
+            System.getProperty("java.version");
+  }
 }


### PR DESCRIPTION
Mainly for android support as Android 5.0 doesn't allow System.setProperty("java.version", ...)