### PR TITLE
Fixed bug with handleNumericConversion and hex literals.

### DIFF
--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -1642,7 +1642,7 @@ public class ParseTools {
         }
       }
 
-      return Integer.decode(new String(val));
+      return Integer.decode(new String(val, start, offset));
     }
     else if (!isDigit(val[start + offset - 1])) {
       switch (val[start + offset - 1]) {

--- a/src/test/java/org/mvel2/util/ParseToolsTest.java
+++ b/src/test/java/org/mvel2/util/ParseToolsTest.java
@@ -1,0 +1,25 @@
+package org.mvel2.util;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Ken Scoggins
+ */
+public class ParseToolsTest extends TestCase {
+
+  /**
+   * Test a bug that appears to have been introduced in 2.1.0 (commit 86b3331547a20ec28250d02a4f2ed0d679aed664)
+   * where the full expression was being passed to Integer.decode, not the literal token, causing a
+   * NumberFormatException for expressions with Oct or Hex literals.
+   */
+  public void testHandleNumericConversionBug() {
+    String[] testLiterals = {"0x20","020",};
+    String baseExpression = "int foo = ";
+
+    for( String literal : testLiterals ) {
+      char[] decExpr = ( baseExpression + literal ).toCharArray();
+      assertEquals( Integer.decode( literal ),
+                    ParseTools.handleNumericConversion( decExpr, baseExpression.length(), literal.length() ) );
+    }
+  }
+}


### PR DESCRIPTION
When the token was a hex literal, handleNumericConversion was expecting the old API style where the val arg is the token itself, not the full expression.  It looks like this was missed because existing unit tests evaluate a hex literal by itself and not a hex as part of an expression.

It looks like ParseTools.java:1677 may have this bug as well, but it appears to be unreachable code and I couldn't verify it, so I left it alone.  Those that know the code better than me can change it if needed.
        case DataTypes.BIG_DECIMAL:
          return new BigDecimal(val, MathContext.DECIMAL128);
