### PR TITLE
Fix NPE when using mvel compiled expression from bootstrap classloader

### DIFF
--- a/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
+++ b/src/main/java/org/mvel2/optimizers/OptimizerFactory.java
@@ -42,7 +42,11 @@ public class OptimizerFactory {
      * By default, activate the JIT if ASM is present in the classpath
      */
     try {
-      OptimizerFactory.class.getClassLoader().loadClass("org.mvel2.asm.ClassWriter");
+      if (OptimizerFactory.class.getClassLoader() != null) {
+          OptimizerFactory.class.getClassLoader().loadClass("org.mvel2.asm.ClassWriter");
+      } else {
+          ClassLoader.getSystemClassLoader().loadClass("org.mvel2.asm.ClassWriter");
+      }
       accessorCompilers.put("ASM", new ASMAccessorOptimizer());
     }
     catch (ClassNotFoundException e) {


### PR DESCRIPTION
The exception is:

2015-07-24 16:17:08,616 ERROR [stderr] (default task-1) java.lang.NullPointerException
2015-07-24 16:17:08,617 ERROR [stderr] (default task-1) 	at org.mvel2.optimizers.OptimizerFactory.<clinit>(OptimizerFactory.java:45)
2015-07-24 16:17:08,617 ERROR [stderr] (default task-1) 	at org.mvel2.ast.ASTNode.optimize(ASTNode.java:145)
2015-07-24 16:17:08,617 ERROR [stderr] (default task-1) 	at org.mvel2.ast.ASTNode.getReducedValueAccelerated(ASTNode.java:115)
2015-07-24 16:17:08,617 ERROR [stderr] (default task-1) 	at org.mvel2.compiler.ExecutableAccessor.getValue(ExecutableAccessor.java:42)
2015-07-24 16:17:08,617 ERROR [stderr] (default task-1) 	at org.mvel2.MVEL.executeExpression(MVEL.java:969)

