### PR TITLE
Fix bc19e182395f45ce53ea7303098e805de50640e1 commit

### DIFF
--- a/src/main/java/org/mvel2/PropertyAccessor.java
+++ b/src/main/java/org/mvel2/PropertyAccessor.java
@@ -954,6 +954,13 @@ public class PropertyAccessor {
         addMethodCache(cls, createSignature(name, tk), m);
         parameterTypes = m.getParameterTypes();
       }
+
+      if (m == null) {
+        if ((m = getBestCandidate(args, name, cls, cls.getMethods(), false)) != null) {
+          addMethodCache(cls, createSignature(name, tk), m);
+          parameterTypes = m.getParameterTypes();
+        }
+      }
     }
 
     if (ctx instanceof PrototypalFunctionInstance) {


### PR DESCRIPTION
Class O1 has method getObj1(). getObj1() declared to return Object
Class O2 extend O3 and O3 has method getObj2(), but O2 does not override getObj2()

If we evaluate getObj1().getObj2() then method getObj2() will not be found