### PR TITLE
Use jboss-parent:19 + needed fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>19</version>
+    </parent>
     <groupId>org.mvel</groupId>
     <artifactId>mvel2</artifactId>
     <packaging>jar</packaging>
@@ -67,19 +72,10 @@
         </mailingList>
     </mailingLists>
     
-    <!--<pluginRepositories>-->
-    <!--<pluginRepository>-->
-    <!--<id>apache-snapshots</id>-->
-    <!--<name>Apache Snapshot Repository</name>-->
-    <!--<url>http://repository.apache.org/snapshots/</url>-->
-    <!--<snapshots>-->
-    <!--<enabled>true</enabled>-->
-    <!--</snapshots>-->
-    <!--</pluginRepository>-->
-    <!--</pluginRepositories>-->
-
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Overwrite source + target versions (1.7 in parent) -->
+        <maven.compiler.source>1.5</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
     </properties>
     <build>
         <extensions>
@@ -93,7 +89,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -116,10 +111,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -127,7 +119,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -148,12 +139,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
+                            <goal>jar-no-fork</goal>
+                            <goal>test-jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -162,9 +152,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.7.2</version>
                 <configuration>
                     <childDelegation>true</childDelegation>
+                    <runOrder>alphabetical</runOrder>
                     <systemProperties>
                         <property>
                             <name>mvel.disable.jit</name>
@@ -199,13 +189,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>2.5.3</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -263,29 +252,12 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.3.1</version>
+            <version>1.4.7</version>
             <scope>test</scope>
         </dependency>
 
-        <!--<dependency>-->
-        <!--<groupId>org.hibernate</groupId>-->
-        <!--<artifactId>ejb3-persistence</artifactId>-->
-        <!--<version>1.0.2.GA</version>-->
-        <!--<scope>test</scope>-->
-        <!--</dependency>        -->
     </dependencies>
 
-    <distributionManagement>
-        <repository>
-            <id>jboss-releases-repository</id>
-            <name>JBoss Releases Repository</name>
-            <url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>jboss-snapshots-repository</id>
-            <name>JBoss Snapshot Repository</name>
-            <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
-
+    <!-- distributionManagement is inherited from parent -->
+    <!--<distributionManagement/>-->
 </project>

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -4017,6 +4017,7 @@ public class CoreConfidenceTests extends AbstractTest {
   }
 
   public void testDhanji2() {
+    OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
     String ex =
         "name = null;\n" +
             "$_1 = ?name.?toLowerCase();\n";


### PR DESCRIPTION
 * this basically brings updates to almost
   all plugins. Upgrading continuesly is much
   easier than big bag changes once in long time
   (e.g. when we will need support for JDK 9)

 * tests are configured to run in alphabetical order
   to avoid different behavior on different machines

@mariofusco please take a look