### PR TITLE
Fixes for Java 9

### DIFF
--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -223,14 +223,7 @@ public class AbstractParser implements Parser, Serializable {
 
       CLASS_LITERALS.put("Array", java.lang.reflect.Array.class);
 
-      if (parseDouble(PropertyTools.getJavaVersion().substring(0, 3)) >= 1.5) {
-        try {
-          CLASS_LITERALS.put("StringBuilder", currentThread().getContextClassLoader().loadClass("java.lang.StringBuilder"));
-        }
-        catch (Exception e) {
-          throw new RuntimeException("cannot resolve a built-in literal", e);
-        }
-      }
+      CLASS_LITERALS.put("StringBuilder", StringBuilder.class);
 
       // Setup LITERALS
       LITERALS.putAll(CLASS_LITERALS);

--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -79,21 +79,6 @@ public class ParseTools {
   public static final Object[] EMPTY_OBJ_ARR = new Object[0];
   public static final Class[] EMPTY_CLS_ARR = new Class[0];
 
-  static {
-    try {
-      double version = parseDouble(PropertyTools.getJavaVersion().substring(0, 3));
-      if (version < 1.5) {
-        throw new RuntimeException("unsupported java version: " + version);
-      }
-    }
-    catch (RuntimeException e) {
-      throw e;
-    }
-    catch (Exception e) {
-      throw new RuntimeException("unable to initialize math processor", e);
-    }
-  }
-
   public static List<char[]> parseMethodOrConstructor(char[] parm) {
     int start = -1;
     for (int i = 0; i < parm.length; i++) {


### PR DESCRIPTION
 * versioning scheme changed in Java 9
 * some code was removed because it cheched for Java
   version < 1.5, which is no longer supported
   (source + target version is set to 1.5). Also the code
   would never be executed anyway since the JVM would
   fail to load the class compiled for newer version of Java

@mariofusco please take a look