### PR TITLE
Fix case with overloaded methods.

### DIFF
--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -376,13 +376,14 @@ public class ParseTools {
   }
 
   public static Method getExactMatch(String name, Class[] args, Class returnType, Class cls) {
-    for (Method meth : cls.getMethods()) {
+	outer:
+	for (Method meth : cls.getMethods()) {
       if (name.equals(meth.getName()) && returnType == meth.getReturnType()) {
         Class[] parameterTypes = meth.getParameterTypes();
         if (parameterTypes.length != args.length) continue;
 
         for (int i = 0; i < parameterTypes.length; i++) {
-          if (parameterTypes[i] != args[i]) return null;
+          if (parameterTypes[i] != args[i]) continue outer;
         }
         return meth;
       }

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -34,6 +34,7 @@ import org.mvel2.tests.core.res.KnowledgeHelperFixer;
 import org.mvel2.tests.core.res.MapObject;
 import org.mvel2.tests.core.res.MyClass;
 import org.mvel2.tests.core.res.MyInterface;
+import org.mvel2.tests.core.res.OverloadedInterface;
 import org.mvel2.tests.core.res.PojoStatic;
 import org.mvel2.tests.core.res.RuleBase;
 import org.mvel2.tests.core.res.RuleBaseImpl;
@@ -47,6 +48,7 @@ import org.mvel2.tests.core.res.WorkingMemory;
 import org.mvel2.tests.core.res.WorkingMemoryImpl;
 import org.mvel2.tests.core.res.res2.ClassProvider;
 import org.mvel2.tests.core.res.res2.Outer;
+import org.mvel2.tests.core.res.res2.OverloadedClass;
 import org.mvel2.tests.core.res.res2.PublicClass;
 import org.mvel2.util.ParseTools;
 import org.mvel2.util.ReflectionUtil;
@@ -4482,4 +4484,13 @@ public class CoreConfidenceTests extends AbstractTest {
     assertEquals(Object.class, MVEL.analyze("a.getSomething()", parserContext));
     assertEquals(String.class, MVEL.analyze("b.getSomething()", parserContext));
   }
+  
+  
+  public void testMethodOverloadMatch() throws Exception {
+	  OverloadedClass c = new OverloadedClass();
+	  Method found  = ParseTools.getExactMatch("putXX", new Class[]{int.class, String.class}, void.class, OverloadedInterface.class);
+	  Method correct = OverloadedInterface.class.getMethod("putXX", new Class[]{int.class, String.class});
+	  assertEquals(correct, found);
+  }
+  
 }

--- a/src/test/java/org/mvel2/tests/core/res/OverloadedInterface.java
+++ b/src/test/java/org/mvel2/tests/core/res/OverloadedInterface.java
@@ -1,0 +1,11 @@
+package org.mvel2.tests.core.res;
+
+public interface OverloadedInterface {
+
+	public void putXX(int a, int b);
+	
+	public void putXX(int a, String b[]);
+	
+	public void putXX(int a, String b);
+	
+}

--- a/src/test/java/org/mvel2/tests/core/res/res2/OverloadedClass.java
+++ b/src/test/java/org/mvel2/tests/core/res/res2/OverloadedClass.java
@@ -1,0 +1,16 @@
+package org.mvel2.tests.core.res.res2;
+
+import org.mvel2.tests.core.res.OverloadedInterface;
+
+public class OverloadedClass implements OverloadedInterface{
+
+	public void putXX(int a, int b) {
+	}
+
+	public void putXX(int a, String b) {
+	}
+	
+	public void putXX(int a, String[] b) {
+	}
+	
+}


### PR DESCRIPTION
I found a case when ParseTools.getExactMatch function doesn't return proper method. Test case attached and the logic flaw there is pretty obvious (when iterating through the arguments it should make sure they are all equal and not return null on first difference because there may be a better overloaded method)

I found this being a root cause of a production problem I had when this method was called from a getWidenedTarget after an IllegalAccessException in PropertyAccessor.getMethod. The exception was thrown correctly (the method in the class was marked as package private so it wasn't visible indeed) but the handling failed due to above getExactMatch problem.

