### PR TITLE
added NoContextErrorTest which demonstrates a problem with "no contex…

### DIFF
--- a/src/test/java/org/mvel2/bugs/NoContextErrorTest.java
+++ b/src/test/java/org/mvel2/bugs/NoContextErrorTest.java
@@ -1,0 +1,26 @@
+package org.mvel2.bugs;
+import java.io.Serializable;
+
+import org.mvel2.MVEL;
+
+import junit.framework.TestCase;
+
+public class NoContextErrorTest extends TestCase {
+  
+  private static final String TEST_CODE = 
+            "for (int i=0; i < 1; i++) {System.err.println(\"for with i\");} "+
+            "for (int j=0; j < 1; j++) {System.err.println(\"for with j\");}";
+
+  // this test fails with exception and message "no context"
+  public void testEval() throws Exception {
+    MVEL.eval(TEST_CODE);
+  }
+
+  // this test is ok and in console there will be 
+  // for with i
+  // for with j
+  public void testCompile() throws Exception {
+    Serializable compile = MVEL.compileExpression(TEST_CODE);
+    MVEL.executeExpression(compile);
+  }
+}


### PR DESCRIPTION
This is a commit with a test demonstrating a regression problem in MVEL 2.2.3:

I have a problem with MVEL running very simple 2-lines script like this:

for (int i=0; i < 1; i++) {}
for (int j=0; j < 1; j++) {}

With MVEL library of version 2.2.3 and higher there is always such error:

Exception in thread "main" java.lang.RuntimeException: no context

This "no context" error message doesn't specify a problem in script and I'm not sure if it's a regression issue in library or some new special thing in MVEL syntax requirements. According to the spec the standard C-style for-loop should be supported and it worked fine with MVEL before 2.2.3.

This error can be seen only with MVEL.eval(..) but MVEL.executeExpression(compiled) still works well.

http://stackoverflow.com/questions/35291421/mvel-script-execution-error-no-context-after-library-update
