### PR TITLE
Fix for https://github.com/mikebrock/mvel/issues/27

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -85,7 +85,7 @@ public class ASMAccessorOptimizer extends AbstractOptimizer implements AccessorO
       OPCODES_VERSION = Opcodes.V1_4;
     else if (javaVersion.startsWith("1.5"))
       OPCODES_VERSION = Opcodes.V1_5;
-    else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7"))
+    else if (javaVersion.startsWith("1.6") || javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8"))
       OPCODES_VERSION = Opcodes.V1_6;
     else
       OPCODES_VERSION = Opcodes.V1_2;


### PR DESCRIPTION
We came across the problem mentioned in https://github.com/mikebrock/mvel/issues/27

and unfortunately, we cannot move to latest version of MVEL2.  We tried with below change and it works for us with Java 8. Is this something we can release part of 2.1.X releases, may be as 2.1.10.Final?  And unfortunately, I am not finding any branch associated to 2.1. releases but can see tags. Please let me know if you are fine with this change but re-create PR against a different branch.


