### PR TITLE
Allow to push and pop the current context stack in a MVEL shell

### DIFF
--- a/src/main/java/org/mvel2/sh/ShellSession.java
+++ b/src/main/java/org/mvel2/sh/ShellSession.java
@@ -47,10 +47,11 @@ public class ShellSession {
   public static final String PROMPT_VAR = "$PROMPT";
   private static final String[] EMPTY = new String[0];
 
-  private final Map<String, Command> commands = new HashMap<String, Command>();
+  private final Map<String, Command> commands = new TreeMap<String, Command>();
   private Map<String, Object> variables;
   private Map<String, String> env;
   private Object ctxObject;
+  private Stack<Object> ctxStack = new Stack<Object>();
 
   ParserContext pCtx = new ParserContext();
   VariableResolverFactory lvrf;
@@ -107,7 +108,7 @@ public class ShellSession {
     }
 
     lvrf = new MapVariableResolverFactory(variables, new MapVariableResolverFactory(env));
-
+    variables.put("t", "Zurück");
   }
 
   public ShellSession(String init) {
@@ -361,7 +362,6 @@ public class ShellSession {
 
   //todo: fix this
   public void run() {
-    final BufferedReader readBuffer = new BufferedReader(new InputStreamReader(System.in));
 
     try {
       //noinspection InfiniteLoopStatement
@@ -446,7 +446,24 @@ public class ShellSession {
   }
 
   public void setCtxObject(Object ctxObject) {
-    this.ctxObject = ctxObject;
+    pushCtxObject(ctxObject);
+  }
+
+  public boolean pushCtxObject(Object ctxObject) {
+    if (this.ctxObject != ctxObject) {
+      ctxStack.push(this.ctxObject);
+      this.ctxObject = ctxObject;
+      return true;
+    }
+    return false;
+  }
+
+  public boolean popCtxObject() {
+    if (!ctxStack.isEmpty()) {
+      ctxObject = ctxStack.pop();
+      return true;
+    }
+    return false;
   }
 
   public String getCommandBuffer() {

--- a/src/main/java/org/mvel2/sh/ShellSession.java
+++ b/src/main/java/org/mvel2/sh/ShellSession.java
@@ -108,7 +108,7 @@ public class ShellSession {
     }
 
     lvrf = new MapVariableResolverFactory(variables, new MapVariableResolverFactory(env));
-    variables.put("t", "Zurück");
+
   }
 
   public ShellSession(String init) {
@@ -362,6 +362,7 @@ public class ShellSession {
 
   //todo: fix this
   public void run() {
+    final BufferedReader readBuffer = new BufferedReader(new InputStreamReader(System.in));
 
     try {
       //noinspection InfiniteLoopStatement

--- a/src/main/java/org/mvel2/sh/command/basic/BasicCommandSet.java
+++ b/src/main/java/org/mvel2/sh/command/basic/BasicCommandSet.java
@@ -31,8 +31,10 @@ public class BasicCommandSet implements CommandSet {
 
     cmds.put("set", new Set());
     cmds.put("push", new PushContext());
+    cmds.put("pop", new PopContext());
     cmds.put("help", new Help());
     cmds.put("showvars", new ShowVars());
+    cmds.put("showenv", new ShowEnv());
     cmds.put("inspect", new ObjectInspector());
     cmds.put("exit", new Exit());
 

--- a/src/main/java/org/mvel2/sh/command/basic/ObjectInspector.java
+++ b/src/main/java/org/mvel2/sh/command/basic/ObjectInspector.java
@@ -39,17 +39,22 @@ public class ObjectInspector implements Command {
 
   public Object execute(ShellSession session, String[] args) {
 
-    if (args.length == 0) {
-      System.out.println("inspect: requires an argument.");
-      return null;
-    }
+    Object val;
 
-    if (!session.getVariables().containsKey(args[0])) {
+    if (args.length == 0) {
+      val = session.getCtxObject();
+      if (val == null) {
+        System.out.println("inspect: requires an argument or a session context.");
+        return null;
+      }
+    }
+    else if (!session.getVariables().containsKey(args[0])) {
       System.out.println("inspect: no such variable: " + args[0]);
       return null;
     }
-
-    Object val = session.getVariables().get(args[0]);
+    else {
+      val = session.getVariables().get(args[0]);
+    }
 
     System.out.println("Object Inspector");
     System.out.println(TextUtil.paint('-', PADDING));
@@ -77,7 +82,9 @@ public class ObjectInspector implements Command {
       serialized = false;
     }
 
-    write("VariableName", args[0]);
+    if (args.length > 0) {
+      write("VariableName", args[0]);
+    }
     write("Hashcode", val.hashCode());
     write("ClassType", cls.getName());
     write("Serializable", serialized);

--- a/src/main/java/org/mvel2/sh/command/basic/PopContext.java
+++ b/src/main/java/org/mvel2/sh/command/basic/PopContext.java
@@ -17,29 +17,20 @@
  */
 package org.mvel2.sh.command.basic;
 
-import org.mvel2.MVEL;
 import org.mvel2.sh.Command;
 import org.mvel2.sh.ShellSession;
 
-public class PushContext implements Command {
+public class PopContext implements Command {
 
   public Object execute(ShellSession session, String[] args) {
-    boolean changed;
-
-    if (args.length == 0) {
-      changed = session.pushCtxObject(null);
-    }
-    else {
-      changed = session.pushCtxObject(MVEL.eval(args[0], session.getCtxObject(), session.getVariables()));
-    }
-    if (changed) {
-      System.out.println("Pushed context to " + session.getCtxObject());
+    if (session.popCtxObject()) {
+      System.out.println("Popped context to " + session.getCtxObject());
     }
     return session.getCtxObject();
   }
 
   public String getDescription() {
-    return "pushes the given variable to the current context";
+    return "pops the previous context from the context queue";
   }
 
   public String getHelp() {

--- a/src/main/java/org/mvel2/sh/command/basic/PushContext.java
+++ b/src/main/java/org/mvel2/sh/command/basic/PushContext.java
@@ -24,18 +24,28 @@ import org.mvel2.sh.ShellSession;
 public class PushContext implements Command {
 
   public Object execute(ShellSession session, String[] args) {
-    boolean changed;
+    boolean changed = false;
+    Object ctx;
 
     if (args.length == 0) {
       changed = session.pushCtxObject(null);
     }
     else {
-      changed = session.pushCtxObject(MVEL.eval(args[0], session.getCtxObject(), session.getVariables()));
+      try {
+        ctx = MVEL.eval(String.join(" ", args), session.getCtxObject(), session.getVariables());
+        if (ctx != null) {
+          changed = session.pushCtxObject(ctx);
+        }
+      }
+      catch (Exception ex) {
+        System.err.println(ex.getMessage());
+      }
     }
+    ctx = session.getCtxObject();
     if (changed) {
-      System.out.println("Pushed context to " + session.getCtxObject());
+      System.out.println("Pushed context to " + ctx);
     }
-    return session.getCtxObject();
+    return ctx;
   }
 
   public String getDescription() {

--- a/src/main/java/org/mvel2/sh/command/basic/Set.java
+++ b/src/main/java/org/mvel2/sh/command/basic/Set.java
@@ -19,7 +19,6 @@
 package org.mvel2.sh.command.basic;
 
 import org.mvel2.sh.Command;
-import org.mvel2.sh.CommandException;
 import org.mvel2.sh.ShellSession;
 import org.mvel2.util.StringAppender;
 
@@ -30,23 +29,26 @@ public class Set implements Command {
 
     Map<String, String> env = session.getEnv();
 
-    if (args.length == 0) {
-      for (String var : env.keySet()) {
-        System.out.println(var + " = " + env.get(var));
-      }
-    }
-    else if (args.length == 1) {
-      throw new CommandException("incorrect number of parameters");
-    }
-    else {
-      StringAppender sbuf = new StringAppender();
-      for (int i = 1; i < args.length; i++) {
-        sbuf.append(args[i]);
-        if (i < args.length) sbuf.append(" ");
-      }
-
-      env.put(args[0], sbuf.toString().trim());
-    }
+    switch (args.length) {
+      case 0:
+        for (String var : env.keySet()) {
+          System.out.println(var + " = " + env.get(var));
+        }
+        break;
+      case 1:
+        String removed = env.remove(args[0]);
+        if (removed != null) {
+          System.out.println("Removed " + args[0] + " = " + removed);
+        }
+        break;
+      default:
+        StringAppender sbuf = new StringAppender();
+        for (int i = 1; i < args.length; i++) {
+          sbuf.append(args[i]);
+          if (i < args.length) sbuf.append(" ");
+        }		  env.put(args[0], sbuf.toString().trim());
+        break;
+	  }
 
     return null;
   }

--- a/src/main/java/org/mvel2/sh/command/basic/ShowEnv.java
+++ b/src/main/java/org/mvel2/sh/command/basic/ShowEnv.java
@@ -1,0 +1,48 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvel2.sh.command.basic;
+
+import org.mvel2.sh.Command;
+import org.mvel2.sh.ShellSession;
+
+import java.util.Map;
+
+public class ShowEnv implements Command {
+
+  public Object execute(ShellSession session, String[] args) {
+
+    Map<String, String> env = session.getEnv();
+
+    System.out.println("Printing Environment ...");
+    for (String key : env.keySet()) {
+      System.out.println(key + " => " + env.get(key));
+    }
+
+    System.out.println(" ** " + env.size() + " environment variables total.");
+
+    return null;
+  }
+
+  public String getDescription() {
+    return "shows current environment";
+  }
+
+  public String getHelp() {
+    return "no help yet";
+  }
+}


### PR DESCRIPTION
This patch allows to push and pop the current context stack in a MVEL shell. The "pop" counterpart to "push" was missing so far. Both allow now for quickly navigating between different context objects. 
Other changes are minor improvements to basic commands: "inspect" without an argument will now inspect the current context, "set" without a 2nd argument can unset an environment variable, and "showenv" wil print all environment variables (similar to "showvars").
