### PR TITLE
Added possibilty for 'whitelist' check to improve securtiy

### DIFF
--- a/src/main/java/org/mvel2/ParserConfiguration.java
+++ b/src/main/java/org/mvel2/ParserConfiguration.java
@@ -47,6 +47,7 @@ public class ParserConfiguration implements Serializable {
   protected Map<String, Object> imports;
   protected HashSet<String> packageImports;
   protected Map<String, Interceptor> interceptors;
+  protected boolean isStrict = false;
   protected transient ClassLoader classLoader;
 
   private transient Set<String> nonValidImports;
@@ -310,5 +311,13 @@ public class ParserConfiguration implements Serializable {
 
   public void setAllowBootstrapBypass(boolean allowBootstrapBypass) {
     this.allowBootstrapBypass = allowBootstrapBypass;
+  }
+  
+  public boolean isStrict() {
+    return isStrict;
+  }
+
+  public void setStrict(boolean isStrict) {
+    this.isStrict = isStrict;
   }
 }

--- a/src/main/java/org/mvel2/ParserContext.java
+++ b/src/main/java/org/mvel2/ParserContext.java
@@ -1084,4 +1084,8 @@ public class ParserContext implements Serializable {
 
     return this;
   }
+  
+  public boolean isStrict() {
+    return parserConfiguration.isStrict();
+  }
 }

--- a/src/main/java/org/mvel2/ast/NewObjectNode.java
+++ b/src/main/java/org/mvel2/ast/NewObjectNode.java
@@ -206,6 +206,10 @@ public class NewObjectNode extends ASTNode {
             .getValue(ctx, thisValue, factory);
       }
 
+      if(pCtx.isStrict() && !pCtx.hasImport(typeDescr.getClassName())){
+    	  throw new CompileException("cannot construct object: " + typeDescr.getClassName() + " it is not a whitelist class", expr, start);
+      }
+
       try {
         AccessorOptimizer optimizer = getThreadAccessorOptimizer();
 

--- a/src/main/java/org/mvel2/compiler/PropertyVerifier.java
+++ b/src/main/java/org/mvel2/compiler/PropertyVerifier.java
@@ -253,6 +253,9 @@ public class PropertyVerifier extends AbstractOptimizer {
       fqcn = true;
       resolvedExternally = false;
       if (tryStaticMethodRef instanceof Class) {
+        if(pCtx.isStrict() && !pCtx.hasImport(((Class) tryStaticMethodRef).getName())){
+           throw new CompileException("illegal import in verifier: ", expr, start);
+        }
         classLiteral = !(MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS &&
             new String(expr, end - 6, 6).equals(".class"));
           return classLiteral ? (Class) tryStaticMethodRef : Class.class;


### PR DESCRIPTION
By default MVEL will invoke every Class. This very dangerous as a scripts like… @{Runtime.getRuntime().exec(\"do what ever you like on the machine\")}  can do a lot of evil stuff. My idea is to limit the access to classes (class construction and static access) to a ‘whitelist’ within the ParserConfiguration if needed. Therefore I included an isStrict option