### PR TITLE
Preserve parser context when optimizing collections

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -3008,6 +3008,7 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
     this.ctx = ctx;
     this.thisRef = thisRef;
     this.variableFactory = factory;
+    this.pCtx = pCtx;
 
     _initJIT();
 

--- a/src/test/java/org/mvel2/tests/core/osgi/AsmOptimizerOsgiTest.java
+++ b/src/test/java/org/mvel2/tests/core/osgi/AsmOptimizerOsgiTest.java
@@ -1,0 +1,40 @@
+package org.mvel2.tests.core.osgi;
+
+import junit.framework.TestCase;
+import org.mvel2.MVEL;
+import org.mvel2.ParserConfiguration;
+import org.mvel2.ParserContext;
+import org.mvel2.optimizers.dynamic.DynamicOptimizer;
+
+import java.io.Serializable;
+
+public class AsmOptimizerOsgiTest extends TestCase {
+
+    private static ClassLoader NO_MVEL_CL = new NoMvelClassLoader();
+
+    private static class NoMvelClassLoader extends ClassLoader {
+        public NoMvelClassLoader() {
+            super(null);
+        }
+    };
+
+    public void testCollectionAccessWithInvalidThreadClassLoader() {
+        String expression = "['A', 'B', 'C'] contains 'B'";
+
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.setClassLoader(MVEL.class.getClassLoader());
+        Serializable compiledExpression = MVEL.compileExpression(expression, new ParserContext(parserConfiguration));
+
+        ClassLoader currentCl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(NO_MVEL_CL);
+
+            for (int i = 0; i <= DynamicOptimizer.tenuringThreshold; i++) {
+                Object result = MVEL.executeExpression(compiledExpression);
+                assertEquals(Boolean.TRUE, result);
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(currentCl);
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes problem in OSGI environment when optimizer kicks in and collection API is used.

Test, which reproduces problem is provided.
Stack trace for the exception:
```
java.lang.ClassNotFoundException: org.mvel2.compiler.Accessor
at java.lang.ClassLoader.findClass(ClassLoader.java:531)[:1.7.0_95]
at java.lang.ClassLoader.loadClass(ClassLoader.java:425)[:1.7.0_95]
at java.lang.ClassLoader.loadClass(ClassLoader.java:358)[:1.7.0_95]
at java.lang.ClassLoader.defineClass1(Native Method)[:1.7.0_95]
at java.lang.ClassLoader.defineClass(ClassLoader.java:800)[:1.7.0_95]
at java.lang.ClassLoader.defineClass(ClassLoader.java:643)[:1.7.0_95]
at org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer$ContextClassLoader.defineClass(ASMAccessorOptimizer.java:2232)
at org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer.loadClass(ASMAccessorOptimizer.java:2241)
at org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer._initializeAccessor(ASMAccessorOptimizer.java:737)
at org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer.optimizeCollection(ASMAccessorOptimizer.java:3010)
at org.mvel2.optimizers.dynamic.DynamicCollectionAccessor.optimize(DynamicCollectionAccessor.java:90)
at org.mvel2.optimizers.dynamic.DynamicCollectionAccessor.getValue(DynamicCollectionAccessor.java:67)
at org.mvel2.ast.InlineCollectionNode.getReducedValueAccelerated(InlineCollectionNode.java:81)
at org.mvel2.ast.Contains.getReducedValueAccelerated(Contains.java:37)
at org.mvel2.MVELRuntime.execute(MVELRuntime.java:85)
at org.mvel2.compiler.CompiledExpression.getDirectValue(CompiledExpression.java:123)
at org.mvel2.compiler.CompiledExpression.getValue(CompiledExpression.java:119)
at org.mvel2.MVEL.executeExpression(MVEL.java:968)
...
```

See related pull request https://github.com/mvel/mvel/pull/70 which contains more information.