### PR TITLE
Preserve coercion flag for exception block to avoid concurrency issue

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessor.java
@@ -64,6 +64,9 @@ public class FieldAccessor implements AccessorNode {
       }
     }
 
+    // this local field is required to make sure exception block works with the same coercionRequired value
+    // and it is not changed by another thread while setter is invoked 
+    boolean attemptedCoercion = coercionRequired;
     try {
 
       if (coercionRequired) {
@@ -76,7 +79,7 @@ public class FieldAccessor implements AccessorNode {
       }
     }
     catch (IllegalArgumentException e) {
-      if (!coercionRequired) {
+      if (!attemptedCoercion) {
         coercionRequired = true;
         return setValue(ctx, elCtx, variableFactory, value);
       }

--- a/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessorNH.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/nodes/FieldAccessorNH.java
@@ -56,6 +56,9 @@ public class FieldAccessorNH implements AccessorNode {
   }
 
   public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+    // this local field is required to make sure exception block works with the same coercionRequired value
+    // and it is not changed by another thread while setter is invoked 
+    boolean attemptedCoercion = coercionRequired;
     try {
       if (nextNode != null) {
         return nextNode.setValue(ctx, elCtx, variableFactory, value);
@@ -70,7 +73,7 @@ public class FieldAccessorNH implements AccessorNode {
       }
     }
     catch (IllegalArgumentException e) {
-      if (!coercionRequired) {
+      if (!attemptedCoercion) {
         coercionRequired = true;
         return setValue(ctx, elCtx, variableFactory, value);
       }

--- a/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MethodAccessor.java
@@ -83,6 +83,9 @@ public class MethodAccessor extends InvokableAccessor {
   }
 
   private Object executeOverrideTarget(Method o, Object ctx, Object elCtx, VariableResolverFactory vars) {
+    // this local field is required to make sure exception block works with the same coercionNeeded value
+    // and it is not changed by another thread while setter is invoked 
+    boolean attemptedCoercion = coercionNeeded;
     if (!coercionNeeded) {
       try {
         try {
@@ -94,7 +97,7 @@ public class MethodAccessor extends InvokableAccessor {
           }
         }
         catch (IllegalArgumentException e) {
-          if (coercionNeeded) throw e;
+          if (attemptedCoercion) throw e;
 
           coercionNeeded = true;
           return executeOverrideTarget(o, ctx, elCtx, vars);

--- a/src/main/java/org/mvel2/optimizers/impl/refl/nodes/SetterAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/nodes/SetterAccessor.java
@@ -20,6 +20,9 @@ public class SetterAccessor implements AccessorNode {
   public static final Object[] EMPTY = new Object[0];
 
   public Object setValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory, Object value) {
+    // this local field is required to make sure exception block works with the same coercionRequired value
+    // and it is not changed by another thread while setter is invoked 
+    boolean attemptedCoercion = coercionRequired;
     try {
       if (coercionRequired) {
         return method.invoke(ctx, convert(value, targetType));
@@ -36,7 +39,7 @@ public class SetterAccessor implements AccessorNode {
         }
       }
 
-      if (!coercionRequired) {
+      if (!attemptedCoercion) {
         coercionRequired = true;
         return setValue(ctx, elCtx, variableFactory, value);
       }

--- a/src/test/java/org/mvel2/tests/perftests/SetterAccessorConcurrencyTest.java
+++ b/src/test/java/org/mvel2/tests/perftests/SetterAccessorConcurrencyTest.java
@@ -1,0 +1,62 @@
+package org.mvel2.tests.perftests;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.mvel2.MVEL;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.tests.core.res.PojoStatic;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SetterAccessorConcurrencyTest extends TestCase {
+
+	private static final Serializable EXPRESSION = MVEL.compileExpression("pojo.value = 2");
+
+	@Test(timeout = 10000)
+	public void testDynamic() throws Exception {
+		OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
+		// warm up
+		MVEL.executeExpression(EXPRESSION, prepareContext());
+
+		internalConcurrentEvaluation();
+	}
+
+	private void internalConcurrentEvaluation() throws Exception {
+		final int N = 20;
+		final CountDownLatch start = new CountDownLatch(1);
+		final CountDownLatch end = new CountDownLatch(N);
+		final AtomicInteger errors = new AtomicInteger(0);
+		for (int i = 0; i < N; i++) {
+			new Thread(new Runnable() {
+				public void run() {
+					try {
+					    HashMap<Object, Object> vars = prepareContext();
+						start.await();
+                        MVEL.executeExpression(EXPRESSION, vars);
+					} catch (Exception e) {
+						errors.incrementAndGet();
+					} finally {
+						end.countDown();
+					}
+				}
+			}, "thread-eval-" + i).start();
+		}
+		start.countDown();
+		assertEquals("Test did not complete withing 10s", true,
+				end.await(10, TimeUnit.SECONDS));
+		if (errors.get() > 0) {
+			fail();
+		}
+	}
+
+    private static HashMap<Object, Object> prepareContext() {
+        HashMap<Object, Object> vars = new HashMap<Object, Object>();
+        vars.put("pojo", new PojoStatic("1"));
+        return vars;
+    }
+
+}


### PR DESCRIPTION
This pull request fixes concurrency problem in SetterAccessor class when optimization kicks in.
See details in following issue: https://github.com/mvel/mvel/issues/98