### PR TITLE
Update ASMAccessorOptimizer.java

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -204,7 +204,7 @@ public class ASMAccessorOptimizer extends AbstractOptimizer implements AccessorO
     synchronized (Runtime.getRuntime()) {
       cw.visit(OPCODES_VERSION, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, className = "ASMAccessorImpl_"
           + valueOf(cw.hashCode()).replaceAll("\\-", "_") + (System.currentTimeMillis() / 10) +
-          ((int) Math.random() * 100),
+          ((int) (Math.random() * 100)),
           null, "java/lang/Object", new String[]{NAMESPACE + "compiler/Accessor"});
     }
 
@@ -235,7 +235,7 @@ public class ASMAccessorOptimizer extends AbstractOptimizer implements AccessorO
     synchronized (Runtime.getRuntime()) {
       cw.visit(OPCODES_VERSION, Opcodes.ACC_PUBLIC + Opcodes.ACC_SUPER, className = "ASMAccessorImpl_"
           + valueOf(cw.hashCode()).replaceAll("\\-", "_") + (System.currentTimeMillis() / 10) +
-          ((int) Math.random() * 100),
+          ((int) (Math.random() * 100)),
           null, "java/lang/Object", new String[]{NAMESPACE + "compiler/Accessor"});
     }
 


### PR DESCRIPTION
There is a bug:
((int) Math.random() * 100) ==0 it did not play the role of random numbers,
when confronted with a large amount of concurrency,it throwed an exception:
java.lang.LinkageError: loader (instance of  org/mvel2/optimizers/dynamic/DynamicClassLoader): attempted  duplicate class definition for name: "ASMAccessorImpl_18581126171481266284560"