### PR TITLE
Property handler should not be auto-registered recursively.

### DIFF
--- a/src/main/java/org/mvel2/integration/PropertyHandlerFactory.java
+++ b/src/main/java/org/mvel2/integration/PropertyHandlerFactory.java
@@ -57,14 +57,7 @@ public class PropertyHandlerFactory {
   }
 
   public static void registerPropertyHandler(Class clazz, PropertyHandler propertyHandler) {
-    do {
-      propertyHandlerClass.put(clazz, propertyHandler);
-
-      for (Class c : clazz.getInterfaces()) {
-        propertyHandlerClass.put(c, propertyHandler);
-      }
-    }
-    while ((clazz = clazz.getSuperclass()) != null && clazz != Object.class);
+    propertyHandlerClass.put(clazz, propertyHandler);
   }
 
   public static void setNullPropertyHandler(PropertyHandler handler) {

--- a/src/test/java/org/mvel2/tests/core/PropertyHandlerTests.java
+++ b/src/test/java/org/mvel2/tests/core/PropertyHandlerTests.java
@@ -389,4 +389,31 @@ public class PropertyHandlerTests extends TestCase {
 
     assertEquals("foobie", wo.getFieldValue("foo"));
   }
+
+  public class A {}
+
+  public class B extends A implements Cloneable {
+  }
+
+  public class C extends A implements Cloneable {
+    public String prop = "Property";
+  }
+
+  public void testPropertyHandlerPreCompile() {
+    MVEL.COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING = true;
+    PropertyHandlerFactory.registerPropertyHandler(B.class, new PropertyHandler() {
+      @Override
+      public Object getProperty(String name, Object contextObj, VariableResolverFactory variableFactory) {
+        return "Handled property";
+      }
+      @Override
+      public Object setProperty(String name, Object contextObj, VariableResolverFactory variableFactory,
+          Object value) {
+        return null;
+      }
+    });
+
+    Serializable compiled = MVEL.compileExpression("prop");
+    assertEquals("Property", MVEL.executeExpression(compiled, new C()));
+  }
 }


### PR DESCRIPTION
Consider the following two classes A and B.

```java
public class A implements Serializable {
  // ...
}

public class B implements Serializable {
  // ...
}
```

If a custom PropertyHandler is registered to `A`, it is also registered to its interface `Serializable`.
This causes a problem when accessing properties of `B` using pre-compiled expression (please see the attached test case).

If the PropertyHandler is registered to the common interface `Serializable`, it should be applied to both `A` and `B`, of course.

There was a similar report in the mailing list, but it got no reply.
http://markmail.org/message/7yxd5xmkbiccmlfr
