### PR TITLE
[issue-135] The optimization for the Collection.isEmpty() method is f…

### DIFF
--- a/src/main/java/org/mvel2/util/PropertyTools.java
+++ b/src/main/java/org/mvel2/util/PropertyTools.java
@@ -97,6 +97,13 @@ public class PropertyTools {
     String getter = ReflectionUtil.getGetter(property);
 
     Method candidate = null;
+
+    if (Collection.class.isAssignableFrom(clazz) && "isEmpty".equals(isGet)) {
+      try {
+        return Collection.class.getMethod("isEmpty");
+      } catch (NoSuchMethodException ignore) {}
+    }
+
     for (Method meth : clazz.getMethods()) {
       if ((meth.getModifiers() & PUBLIC) != 0 && (meth.getModifiers() & STATIC) == 0 && meth.getParameterTypes().length == 0
           && (getter.equals(meth.getName()) || property.equals(meth.getName()) || ((isGet.equals(meth.getName()) || simpleIsGet.equals(meth.getName())) && meth.getReturnType() == boolean.class)

--- a/src/test/java/org/mvel2/tests/core/PropertyAccessTests.java
+++ b/src/test/java/org/mvel2/tests/core/PropertyAccessTests.java
@@ -468,6 +468,41 @@ public class PropertyAccessTests extends AbstractTest {
     }
   }
 
+  public final class Data {
+
+    private final Collection<Object> list;
+
+    Data(List<Object> list) {
+      this.list = list;
+    }
+
+    public Collection<Object> getList() {
+      return list;
+    }
+  }
+
+  public void testStaleReflectiveCollectionIsEmptyAccessor() {
+    try
+    {
+      OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
+      Serializable getFooExpression = MVEL.compileExpression("list.empty");
+      Map vars = new HashMap();
+
+      // ArrayList -> Colletions.EmptyList
+      assertEquals(true, MVEL.executeExpression(getFooExpression, new Data(new ArrayList<Object>())));
+      assertEquals(true, MVEL.executeExpression(getFooExpression, new Data(Collections.emptyList())));
+
+      // Colletions.EmptyList -> ArrayList
+      assertEquals(true, MVEL.executeExpression(getFooExpression, new Data(Collections.emptyList())));
+      assertEquals(true, MVEL.executeExpression(getFooExpression, new Data(new ArrayList<Object>())));
+      OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
+    }
+    finally
+    {
+      OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
+    }
+  }
+
   public void testMVEL308() {
     String expression = "foreach(field: updates.entrySet()) { ctx._target[field.key] = field.value; }";
     Serializable compiled = MVEL.compileExpression(expression);


### PR DESCRIPTION
…ixed

The reflective getter for collections' empty property is changed to Collection.isEmpty() method to prevent the IllegalAccessException when the context is changed from ArrayList to Collections.EmptyList or from HashSet to Collections.EmptySet and vice versa