### PR TITLE
Fix for ClassCastException when trying to reuse complex functions in multithreaded scenario

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicFunctionAccessor.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/nodes/DynamicFunctionAccessor.java
@@ -19,6 +19,7 @@
 package org.mvel2.optimizers.impl.refl.nodes;
 
 import org.mvel2.ast.Function;
+import org.mvel2.ast.FunctionInstance;
 import org.mvel2.compiler.Accessor;
 import org.mvel2.integration.VariableResolverFactory;
 
@@ -34,7 +35,12 @@ public class DynamicFunctionAccessor extends BaseAccessor {
   public Object getValue(Object ctx, Object elCtx, VariableResolverFactory variableFactory) {
     Object[] parms = null;
 
-    Function function = (Function) ctx;
+    Function function;
+    if (ctx instanceof FunctionInstance){
+      function = ((FunctionInstance)ctx).getFunction();
+    } else {
+      function = (Function)ctx;
+    }
 
     if (parameters != null && parameters.length != 0) {
       parms = new Object[parameters.length];

--- a/src/test/java/org/mvel2/tests/core/res/Member.java
+++ b/src/test/java/org/mvel2/tests/core/res/Member.java
@@ -1,0 +1,20 @@
+package org.mvel2.tests.core.res;
+
+public class Member {
+  private String name;
+  private Integer age;
+
+  public Member(String name, Integer age) {
+    super();
+    this.name = name;
+    this.age = age;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+}

--- a/src/test/java/org/mvel2/tests/core/res/SharedFuncLib.java
+++ b/src/test/java/org/mvel2/tests/core/res/SharedFuncLib.java
@@ -1,0 +1,26 @@
+package org.mvel2.tests.core.res;
+
+import org.mvel2.MVEL;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+import java.util.Map;
+
+public class SharedFuncLib {
+
+  final static VariableResolverFactory functionFactory = new MapVariableResolverFactory();
+
+  static {
+    MVEL.eval(
+    "def round(numValue, decPlaces) { return numValue.setScale(decPlaces,java.math.RoundingMode.HALF_UP) };"
+            + "\n"
+            + "def sum(lst, startValue, accFunc){ s = startValue; foreach (i : lst){ s = s + accFunc(i); } return s;  };",
+    functionFactory);
+  }
+
+  public <T> T eval(String formula, Map<String, Object> context, Class<T> toType) {
+    VariableResolverFactory myVariableResolverFactory = new MapVariableResolverFactory();
+    myVariableResolverFactory.setNextFactory(functionFactory);
+    return MVEL.eval(formula, context, myVariableResolverFactory, toType);
+  }
+}


### PR DESCRIPTION
In my project I wanted to create reusable library of mvel functions - see SharedFuncLib class for example.
When I try to use shared functions in multithreaded environment I get ClassCasetException - cannot cast FunctionInstance to fuction.
This happens only if I have complex function, like function that accepts clousure, which in turn uses other functions.
The same issue was reported for muel-mvel fork and fixed in exactly the same way for older version of mvel.
Please let me know if there is something wrong with my approach to create reusable set of mvel functions, or provided fix is proper solution.