### PR TITLE
There is the java.lang.ArrayIndexOutOfBoundsException if more than 4 whitespaces located behind braces of "if" operator and this operator is the last one in the MVEL expression

### DIFF
--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -1781,7 +1781,7 @@ public class AbstractParser implements Parser, Serializable {
       if (expr[cursor] != ';') cursor--;
       skipWhitespace();
 
-      return expr[cursor] == 'e' && expr[cursor + 1] == 'l' && expr[cursor + 2] == 's' && expr[cursor + 3] == 'e'
+      return (cursor + 4) < end && expr[cursor] == 'e' && expr[cursor + 1] == 'l' && expr[cursor + 2] == 's' && expr[cursor + 3] == 'e'
           && (isWhitespace(expr[cursor + 4]) || expr[cursor + 4] == '{');
     }
     return false;

--- a/src/test/java/org/mvel2/tests/core/ControlFlowTests.java
+++ b/src/test/java/org/mvel2/tests/core/ControlFlowTests.java
@@ -18,7 +18,7 @@ import static org.mvel2.MVEL.executeExpression;
 public class ControlFlowTests extends AbstractTest {
 
   public void testSimpleIfStatement() {
-    test("if (true) { System.out.println(\"test!\") }  \n");
+    test("if (true) { System.out.println(\"test!\") }     \n");
   }
 
   public void testAnd() {


### PR DESCRIPTION
The method testSimpleIfStatement() from the org.mvel2.tests.core.ControlFlowTests class is failed if more than 4 whitespaces located behind "{}" braces of "if" operator (e.g. "if() {}          ").

It is because the method ifThenElseBlockContinues() from the org.mvel2.compiler.AbstractParser class is trying to check 'e' 'l' 's' 'e' letters behind the if-operator when the position of the cursor is equal with the end of expression string.
It throws java.lang.ArrayIndexOutOfBoundsException.

It can easy check just adding more than 3 whitespace to existing 2 whitespaces in the MVEL source code https://github.com/mvel/mvel/blob/master/src/test/java/org/mvel2/tests/core/ControlFlowTests.java
 and run this test. It will throw exception and test will be failed:

original method, there are 2 whitespaces (test - ok):

```
  public void testSimpleIfStatement() {
    test("if (true) { System.out.println(\"test!\") }  \n");
  }
```
after adding 3 whitespace there where 5 whitespaces (>4) (test - failed)

```
  public void testSimpleIfStatement() {
    test("if (true) { System.out.println(\"test!\") }     \n");
  }
```

One of the solution there is the checking that the position of the cursor less by 4 than the end of string together with the checking 'e' 'l' 's' 'e' letters.

Most likely the issue https://github.com/mvel/mvel/issues/110 also applies to this case.

PS:
This happened on our two projects, when  "if" operator was located at the end of MVEL expression and this code was reformatted and added more than 9 whitespaces behind curly brace of if-operator. 
And this is also repeatedly happened in our development of configurations under [Apache Camel](https://camel.apache.org/)