### PR TITLE
Can't remove class with AbstractParser#CLASS_LITERALS

### DIFF
--- a/src/main/java/org/mvel2/ParserConfiguration.java
+++ b/src/main/java/org/mvel2/ParserConfiguration.java
@@ -171,7 +171,7 @@ public class ParserConfiguration implements Serializable {
 
   public boolean hasImport(String name) {
     return (imports.containsKey(name)) ||
-        AbstractParser.CLASS_LITERALS.containsKey(name) ||
+        AbstractParser.LITERALS.containsKey(name) ||
         checkForDynamicImport(name);
   }
 

--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -134,7 +134,7 @@ public class AbstractParser implements Parser, Serializable {
   private static final WeakHashMap<String, char[]> EX_PRECACHE = new WeakHashMap<String, char[]>(15);
 
   public static HashMap<String, Object> LITERALS;
-  public static HashMap<String, Object> CLASS_LITERALS;
+  protected static HashMap<String, Object> CLASS_LITERALS;
   public static HashMap<String, Integer> OPERATORS;
 
   protected ExecutionStack stk;


### PR DESCRIPTION
Sometimes if I want to forbid some classes in expression such as:
```java
Runtime.getRuntime().exec(command);
// or
System.exit(0);
```

I can remove them like this:
```java
AbstractParser.LITERALS.remove("System")
// or
AbstractParser.CLASS_LITERALS.remove("Runtime")
```

But if I remove a class with `CLASS_LITERALS`, it will still in `LITERALS`, because of       [`LITERALS.putAll(CLASS_LITERALS)`](https://github.com/mvel/mvel/blob/master/src/main/java/org/mvel2/compiler/AbstractParser.java#L226),  and [`ParserConfiguration#hasImport`](https://github.com/mvel/mvel/blob/master/src/main/java/org/mvel2/ParserConfiguration.java#L174) is also true.

So that
1. make `AbstractParser#CLASS_LITERALS` protected.
2. change `CLASS_LITERALS` to `LITERALS` in [`ParserConfiguration#hasImport`](https://github.com/mvel/mvel/blob/master/src/main/java/org/mvel2/ParserConfiguration.java#L174) when test if the specified import exists.
