### PR TITLE
Issue181 - Nested property access successful in ReflectiveAccessorOptimizer but fails in ASMAccessorOptimizer

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -1394,7 +1394,7 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
     }
 
     ExecutableStatement compiled = (ExecutableStatement) subCompileExpression(tk.toCharArray(), pCtx);
-    Object item = compiled.getValue(ctx, variableFactory);
+    Object item = compiled.getValue(this.ctx, variableFactory);
 
     ++cursor;
 
@@ -2637,14 +2637,6 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
 
 
   private Object addSubstatement(ExecutableStatement stmt) {
-    if (stmt instanceof ExecutableAccessor) {
-      ExecutableAccessor ea = (ExecutableAccessor) stmt;
-      if (ea.getNode().isIdentifier() && !ea.getNode().isDeepProperty()) {
-        loadVariableByName(ea.getNode().getName());
-        return null;
-      }
-    }
-
     compiledInputs.add(stmt);
 
     assert debug("ALOAD 0");


### PR DESCRIPTION
- Use original ctx rather than collection ctx in getCollectionProperty
- Remove problematic optimization in addSubstatement since it assumes that the index is either litteral or in the VariableResolver
- Add unit test to demonstrate issue and fix