### PR TITLE
Issue113 - mvel throw FastList casting exception under high concurrency

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -1997,24 +1997,25 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
         }
       }
 
+      Class<?> declaringClass = m.getDeclaringClass();
       if (m.getParameterTypes().length == 0) {
         if ((m.getModifiers() & STATIC) != 0) {
           assert debug("INVOKESTATIC " + m.getName());
-          mv.visitMethodInsn(INVOKESTATIC, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+          mv.visitMethodInsn(INVOKESTATIC, getInternalName(declaringClass), m.getName(), getMethodDescriptor(m));
         }
         else {
-          assert debug("CHECKCAST " + getInternalName(m.getDeclaringClass()));
-          mv.visitTypeInsn(CHECKCAST, getInternalName(m.getDeclaringClass()));
+          assert debug("CHECKCAST " + getInternalName(declaringClass));
+          mv.visitTypeInsn(CHECKCAST, getInternalName(declaringClass));
 
-          if (m.getDeclaringClass().isInterface()) {
+          if (declaringClass.isInterface()) {
             assert debug("INVOKEINTERFACE " + m.getName());
-            mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(m.getDeclaringClass()), m.getName(),
+            mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(declaringClass), m.getName(),
                 getMethodDescriptor(m));
 
           }
           else {
             assert debug("INVOKEVIRTUAL " + m.getName());
-            mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(m.getDeclaringClass()), m.getName(),
+            mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(declaringClass), m.getName(),
                 getMethodDescriptor(m));
           }
         }
@@ -2025,8 +2026,8 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
       }
       else {
         if ((m.getModifiers() & STATIC) == 0) {
-          assert debug("CHECKCAST " + getInternalName(m.getDeclaringClass()));
-          mv.visitTypeInsn(CHECKCAST, getInternalName(m.getDeclaringClass()));
+          assert debug("CHECKCAST " + getInternalName(declaringClass));
+          mv.visitTypeInsn(CHECKCAST, getInternalName(declaringClass));
         }
 
           Class<?> aClass = m.getParameterTypes()[m.getParameterTypes().length - 1];
@@ -2168,18 +2169,17 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
 
         if ((m.getModifiers() & STATIC) != 0) {
           assert debug("INVOKESTATIC: " + m.getName());
-          mv.visitMethodInsn(INVOKESTATIC, getInternalName(m.getDeclaringClass()), m.getName(), getMethodDescriptor(m));
+          mv.visitMethodInsn(INVOKESTATIC, getInternalName(declaringClass), m.getName(), getMethodDescriptor(m));
         }
         else {
-          if (m.getDeclaringClass().isInterface() && (m.getDeclaringClass() != cls
-              || (ctx != null && ctx.getClass() != m.getDeclaringClass()))) {
-            assert debug("INVOKEINTERFACE: " + getInternalName(m.getDeclaringClass()) + "." + m.getName());
-            mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(m.getDeclaringClass()), m.getName(),
+          if (declaringClass.isInterface()) {
+            assert debug("INVOKEINTERFACE: " + getInternalName(declaringClass) + "." + m.getName());
+            mv.visitMethodInsn(INVOKEINTERFACE, getInternalName(declaringClass), m.getName(),
                 getMethodDescriptor(m));
           }
           else {
-            assert debug("INVOKEVIRTUAL: " + getInternalName(cls) + "." + m.getName());
-            mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(cls), m.getName(),
+            assert debug("INVOKEVIRTUAL: " + getInternalName(declaringClass) + "." + m.getName());
+            mv.visitMethodInsn(INVOKEVIRTUAL, getInternalName(declaringClass), m.getName(),
                 getMethodDescriptor(m));
           }
         }

--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -1976,7 +1976,6 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
     }
     else {
       m = getWidenedTarget(m);
-
       if (es != null) {
         ExecutableStatement cExpr;
         for (int i = 0; i < es.length; i++) {
@@ -2026,8 +2025,8 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
       }
       else {
         if ((m.getModifiers() & STATIC) == 0) {
-          assert debug("CHECKCAST " + getInternalName(cls));
-          mv.visitTypeInsn(CHECKCAST, getInternalName(cls));
+          assert debug("CHECKCAST " + getInternalName(m.getDeclaringClass()));
+          mv.visitTypeInsn(CHECKCAST, getInternalName(m.getDeclaringClass()));
         }
 
           Class<?> aClass = m.getParameterTypes()[m.getParameterTypes().length - 1];

--- a/src/test/java/org/mvel2/tests/core/ASMConsistencyTest.java
+++ b/src/test/java/org/mvel2/tests/core/ASMConsistencyTest.java
@@ -1,0 +1,45 @@
+package org.mvel2.tests.core;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Vector;
+
+import org.mvel2.MVEL;
+
+public class ASMConsistencyTest extends AbstractTest {
+  public void testInSetRepeated() throws InterruptedException {
+    String str = "[\"001\", \"002\", \"003\", \"005\", \"007\", \"008\", \"009\"].contains(digest)";
+    final Serializable stmt = MVEL.compileExpression(str);
+    List<Thread> threads = new ArrayList<Thread>();
+    final List<RuntimeException> rex = new Vector<RuntimeException>();
+    for (int i = 0; i < 1000; ++i) {
+      Thread thread = new Thread() {
+        @Override
+        public void run() {
+          for (int i = 0; i < 1000; ++i) {
+            try {
+              Object result = MVEL.executeExpression(stmt, Collections.singletonMap("digest", "00" + (i%10)));
+              assertTrue(result instanceof Boolean);
+            }
+            catch (RuntimeException ex) {
+              rex.add(ex);
+            }
+          }
+        }
+      };
+      threads.add(thread);
+    }
+    for (Thread thread : threads) {
+      thread.start();
+    }
+    for (Thread thread : threads) {
+      thread.join();
+    }
+    if (!rex.isEmpty()) {
+      throw new IllegalStateException("Exception occurred " + rex.size() + " time(s)", rex.get(0));
+    }
+  }
+
+}


### PR DESCRIPTION
Issue is caused by a race condition when sometimes the "contains" call is optimized to ASM by ASMAccessorOptimizer.getMethod() before the ArrayList is optimized to FastList. When the ASM-generated class is invoked later, it will fail because the collection is now a FastList and the generated code contains a CHECKCAST for the original class (ArrayList). However, in ASMAccessorOptimizer.getMethod(), the method has been widened to Collection.contains but the CHECKCAST is still created based on the original class. The fix is to create the CHECKCAST based on the method's declaring class.
