### PR TITLE
Issue89 - IllegalArgumentException in org.mvel2.asm.ClassWriter

### DIFF
--- a/src/main/java/org/mvel2/asm/SymbolTable.java
+++ b/src/main/java/org/mvel2/asm/SymbolTable.java
@@ -27,6 +27,8 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 package org.mvel2.asm;
 
+import org.mvel2.optimizers.OptimizationNotSupported;
+
 /**
  * The constant pool entries, the BootstrapMethods attribute entries and the (ASM specific) type
  * table entries of a class.
@@ -498,7 +500,7 @@ final class SymbolTable {
           constantDynamic.getBootstrapMethod(),
           constantDynamic.getBootstrapMethodArgumentsUnsafe());
     } else {
-      throw new IllegalArgumentException("value " + value);
+      throw new OptimizationNotSupported();
     }
   }
 

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -4696,4 +4696,20 @@ public class CoreConfidenceTests extends AbstractTest {
     int result = (Integer)MVEL.executeExpression(compiledExpr, null, factory);
     assertEquals(expectedResult, result);
   }
+  public void test_BigDecimal_ASMoptimizerSupport() {
+    /* https://github.com/mvel/mvel/issues/89
+     * The following case failed in attempt from the ASM optimizer to 
+     *  create a numeric constant from the value 30000B.
+     */
+    Serializable compiled = MVEL.compileExpression("big = new java.math.BigDecimal(\"10000\"); if (big.compareTo(30000B) > 0) then ;");
+    Map<String, Integer> vars = new HashMap<String, Integer>();
+    for (int i = 0; i < 1000; i++) {
+      try {
+        MVEL.executeExpression(compiled, vars);
+      } catch (CompileException e) {
+        e.printStackTrace();
+        fail("Failed after #executions: " + i);
+      }
+    }
+  }
 }


### PR DESCRIPTION
In SymbolTable.addConstant(), for unimplemented cases, throw OptimizationNotSupported instead of IllegalArgumentException to allow normal processing.