### PR TITLE
Access control on the Java APIs that can be used in MVEL script.

### DIFF
--- a/src/main/java/org/mvel2/integration/ClassAccessHandler.java
+++ b/src/main/java/org/mvel2/integration/ClassAccessHandler.java
@@ -1,0 +1,17 @@
+package org.mvel2.integration;
+
+public interface ClassAccessHandler {
+
+	/**
+	 * Creates object of the class provided  
+	 * 
+	 * returns null if class is not allowed 
+	 * 
+	 * @param name
+	 * @param classloader
+	 * @return the instance object of the provided class
+	 * @throws ClassNotFoundException
+	 */
+	Class<?> getClassInstance(String name, ClassLoader classloader) throws ClassNotFoundException;
+	
+}

--- a/src/main/java/org/mvel2/integration/ClassAccessHandlerFactory.java
+++ b/src/main/java/org/mvel2/integration/ClassAccessHandlerFactory.java
@@ -1,0 +1,21 @@
+package org.mvel2.integration;
+
+import org.mvel2.integration.impl.DefaultClassAccessHandler;
+
+public class ClassAccessHandlerFactory {
+
+	private static ClassAccessHandler classAccessHandler = new DefaultClassAccessHandler();
+
+	public static void registerClassHandler(ClassAccessHandler classHandler) {
+		classAccessHandler = classHandler;
+	}
+	
+	public static void registerDefault() {
+		classAccessHandler = new DefaultClassAccessHandler();
+	}
+	
+	public static ClassAccessHandler getClassAccessHandler() {
+		return classAccessHandler;
+	}
+	
+}

--- a/src/main/java/org/mvel2/integration/impl/DefaultClassAccessHandler.java
+++ b/src/main/java/org/mvel2/integration/impl/DefaultClassAccessHandler.java
@@ -1,0 +1,12 @@
+package org.mvel2.integration.impl;
+
+import org.mvel2.integration.ClassAccessHandler;
+
+public class DefaultClassAccessHandler implements ClassAccessHandler{
+
+	@Override
+	public Class<?> getClassInstance(String name, ClassLoader classloader) throws ClassNotFoundException {
+		return classloader.loadClass(name);
+	}
+
+}

--- a/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
@@ -80,7 +80,7 @@ public class AbstractOptimizer extends AbstractParser {
                 if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && test.endsWith(".class"))
                     test = test.substring(0, test.length() - 6);
 
-                return Class.forName(test, true, classLoader);
+                return loadClass(test, classLoader);
               } catch (ClassNotFoundException cnfe) {
                 try {
                   return findInnerClass( test, classLoader, cnfe );

--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -57,6 +57,7 @@ import org.mvel2.compiler.ExecutableAccessor;
 import org.mvel2.compiler.ExecutableAccessorSafe;
 import org.mvel2.compiler.ExecutableLiteral;
 import org.mvel2.compiler.ExpressionCompiler;
+import org.mvel2.integration.ClassAccessHandlerFactory;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.ClassImportResolverFactory;
 import org.mvel2.math.MathProcessor;
@@ -2194,7 +2195,7 @@ public class ParseTools {
 
   public static Class forNameWithInner(String className, ClassLoader classLoader) throws ClassNotFoundException {
     try {
-      return classLoader.loadClass( className );
+      return loadClass( className , classLoader);
     } catch (ClassNotFoundException cnfe) {
       return findInnerClass( className, classLoader, cnfe );
     }
@@ -2204,9 +2205,13 @@ public class ParseTools {
     for (int lastDotPos = className.lastIndexOf('.'); lastDotPos > 0; lastDotPos = className.lastIndexOf('.')) {
       className = className.substring(0, lastDotPos) + "$" + className.substring(lastDotPos+1);
       try {
-        return classLoader.loadClass( className );
+        return loadClass( className , classLoader);
       } catch (ClassNotFoundException e) { /* ignore */ }
     }
     throw cnfe;
+  }
+  
+  public static Class loadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
+	  return ClassAccessHandlerFactory.getClassAccessHandler().getClassInstance(className, classLoader);
   }
 }

--- a/src/test/java/org/mvel2/test/classHandler/ClassAccessHandlerTest.java
+++ b/src/test/java/org/mvel2/test/classHandler/ClassAccessHandlerTest.java
@@ -1,0 +1,25 @@
+package org.mvel2.test.classHandler;
+
+import org.mvel2.integration.ClassAccessHandlerFactory;
+import org.mvel2.tests.core.AbstractTest;
+
+public class ClassAccessHandlerTest extends AbstractTest{
+	
+	public void testWithRestrictedClass() {
+		ClassAccessHandlerFactory.registerClassHandler(new RestrictedClassAccessTestHandler());
+	    try {
+	    	test("java.lang.System");
+	    } catch(Exception e) {
+	    	if(!e.getCause().getMessage().contains("could not access: java;")) {
+	    		fail();
+	    	}
+	    }
+	    ClassAccessHandlerFactory.registerDefault();
+	}
+	
+	public void testWithUnrestrictedClass() {
+		ClassAccessHandlerFactory.registerClassHandler(new RestrictedClassAccessTestHandler());
+	    assertEquals(Integer.class, test("java.lang.Integer"));
+	    ClassAccessHandlerFactory.registerDefault();
+	}
+}

--- a/src/test/java/org/mvel2/test/classHandler/RestrictedClassAccessTestHandler.java
+++ b/src/test/java/org/mvel2/test/classHandler/RestrictedClassAccessTestHandler.java
@@ -1,0 +1,15 @@
+package org.mvel2.test.classHandler;
+
+import org.mvel2.integration.ClassAccessHandler;
+
+public class RestrictedClassAccessTestHandler implements ClassAccessHandler{
+
+	@Override
+	public Class<?> getClassInstance(String name, ClassLoader classloader) throws ClassNotFoundException {
+		if(name.startsWith("java.lang.System")) {
+			return null;
+		}
+		return classloader.loadClass(name);
+	}
+
+}


### PR DESCRIPTION
I went through the script execution flow and couldn't find a way to have access control on the java classes that can be accessed from the script.

So provided an ClassAccessHandler interface and implemented a defaultClassAccessHandler which has the default behaviour. Otherwise, users can have a custom implementation of the interface and register it to ClassAccessHandlerFactory to have their own access controls.

For example please refer to RestrictedClassAccessTestHandler.java

Would also like to block "this" keyword in the script based on a property. Will update the PR.