### PR TITLE
Fix __resolveType process InternalNumber as Object

### DIFF
--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -1042,6 +1042,7 @@ public class ParseTools {
 
     typeCodes.put(BigDecimal.class, DataTypes.BIG_DECIMAL);
     typeCodes.put(BigInteger.class, DataTypes.BIG_INTEGER);
+    typeCodes.put(InternalNumber.class, DataTypes.BIG_DECIMAL);
 
     typeCodes.put(int.class, DataTypes.INTEGER);
     typeCodes.put(double.class, DataTypes.DOUBLE);

--- a/src/test/java/org/mvel2/tests/core/ArithmeticTests.java
+++ b/src/test/java/org/mvel2/tests/core/ArithmeticTests.java
@@ -1064,4 +1064,11 @@ public class ArithmeticTests extends AbstractTest {
     vars.put("x", 4);
     assertEquals(Math.ceil((double) 4 / 3), MVEL.executeExpression(stmt, vars));
   }
+  
+  public void testBigDecimalAssignmentIncrement() {
+    String str = "s1=0B;s1+=1;s1+=1;s1";
+    Serializable expr = MVEL.compileExpression(str);
+    Object result = MVEL.executeExpression(expr, new HashMap<String, Object>());
+    assertEquals(new BigDecimal(2), result);
+  }
 }


### PR DESCRIPTION
Fix a bug in JDK 8:
s1=0B;s1+=1;s1+=1;s1  will get wrong result 11
while process the first s1+=1(BigDecimal(0) + Integer(1)), BigDecimal(0).add(InternalNumber(1)) -> InternalNumber(1)
and then process the second s1+=1(InternalNumber(1) + Integer(1)), Object + Integer, process as string append, get result 11.

add InternalNumber class in typeCodes map could fix this problem.