### PR TITLE
[JBPM-8900] Check name is not null before invoking isResolveable

### DIFF
--- a/src/main/java/org/mvel2/ast/ASTNode.java
+++ b/src/main/java/org/mvel2/ast/ASTNode.java
@@ -138,7 +138,7 @@ public class ASTNode implements Cloneable, Serializable {
     AccessorOptimizer optimizer;
     Object retVal = null;
 
-    if ((fields & NOJIT) != 0 || factory != null && factory.isResolveable(nameCache)) {
+    if ((fields & NOJIT) != 0 || factory != null && factory.isResolveable(getName())) {
       optimizer = getAccessorCompiler(SAFE_REFLECTIVE);
     }
     else {


### PR DESCRIPTION
This scenario is failing in JBPM :
When there is an ASTNode with deep property ($.firstName), the custom VariableResolver may receive a null string to deal with it.
My proposal is to check if nameCache is not null, before invoking isResolveable.