### PR TITLE
Issue215 DebuggerTests fails sporadically

### DIFF
--- a/src/test/java/org/mvel2/tests/core/DebuggerTests.java
+++ b/src/test/java/org/mvel2/tests/core/DebuggerTests.java
@@ -37,13 +37,12 @@ public class DebuggerTests extends AbstractTest {
   @Override
   protected void setUp() throws Exception {
       super.setUp();
-      MVELRuntime.clearAllBreakpoints();
+      MVELRuntime.resetDebugger();
   }
 
   public void testDebuggerInvoke() {
     count = 0;
 
-    MVELRuntime.resetDebugger();
     MVELRuntime.setThreadDebugger(new Debugger() {
       public int onBreak(Frame frame) {
         if (frame.getFactory().isResolveable("a1")) {
@@ -85,7 +84,6 @@ public class DebuggerTests extends AbstractTest {
   public void testDebuggerInvoke2() {
     count = 0;
 
-    MVELRuntime.resetDebugger();
     MVELRuntime.setThreadDebugger(new Debugger() {
       public int onBreak(Frame frame) {
         count++;

--- a/src/test/java/org/mvel2/tests/core/DebuggerTests.java
+++ b/src/test/java/org/mvel2/tests/core/DebuggerTests.java
@@ -33,6 +33,12 @@ public class DebuggerTests extends AbstractTest {
   private static int count;
   private static int a1 = 0;
   private static int a4 = 0;
+  
+  @Override
+  protected void setUp() throws Exception {
+      super.setUp();
+      MVELRuntime.clearAllBreakpoints();
+  }
 
   public void testDebuggerInvoke() {
     count = 0;


### PR DESCRIPTION
Fixes #215 
Clear global breakpoints before each test so that the breakpoints of one test doesn't affect another test