### PR TITLE
Issue222 Incorrect parsing of some expressions with spaces after dot

### DIFF
--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -1949,7 +1949,10 @@ public class AbstractParser implements Parser, Serializable {
           return;
 
         case '.':
+          // Skip spaces after dot but do not consume following character
+          ++cursor;
           skipWhitespace();
+          --cursor;
           break;
 
         case '\'':

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -4741,4 +4741,16 @@ public class CoreConfidenceTests extends AbstractTest {
       }
     }
   }
+
+  public void testLiteralToStringWithSpaceASM() throws Throwable {
+      OptimizerFactory.setDefaultOptimizer("ASM");
+      testLiteralToStringWithSpace();
+  }
+
+  public void testLiteralToStringWithSpace() throws Throwable {
+      String expr = "'foo'. hashCode()";
+      int hashCode = "foo". hashCode();
+      Serializable s = MVEL.compileExpression(expr);
+      assertEquals(Integer.valueOf(hashCode), MVEL.executeExpression(s));
+  }
 }

--- a/src/test/java/org/mvel2/tests/core/WithTests.java
+++ b/src/test/java/org/mvel2/tests/core/WithTests.java
@@ -189,7 +189,7 @@ public class WithTests extends AbstractTest {
 
     OptimizerFactory.setDefaultOptimizer("reflective");
     assertEquals("ziggy",
-        (((Foo) ((Map) executeExpression(s)).get("foo")).getBar().getName()));
+        (((Foo) ((Map<?, ?>) executeExpression(s)).get("foo")).getBar().getName()));
   }
 
   public void testSataticClassImportViaFactoryAndWithModification() {
@@ -264,7 +264,7 @@ public class WithTests extends AbstractTest {
     recipient2.setName("userName2");
     recipient2.setEmail("user2@domain.com");
 
-    List list = new ArrayList();
+    List<Recipient> list = new ArrayList<Recipient>();
     list.add(recipient1);
     list.add(recipient2);
 
@@ -276,8 +276,8 @@ public class WithTests extends AbstractTest {
 
     ExpressionCompiler compiler = new ExpressionCompiler(text, context);
     Serializable execution = compiler.compile();
-    List result = (List) executeExpression(execution,
-        new HashMap());
+    List<?> result = (List<?>) executeExpression(execution,
+        new HashMap<String, Object>());
     assertEquals(list,
         result);
   }
@@ -345,6 +345,11 @@ public class WithTests extends AbstractTest {
     Serializable s = MVEL.compileExpression(expr);
 
     assertEquals("foo", MVEL.executeExpression(s));
+  }
+
+  public void testInlineWithWithLiteralASM() throws Throwable {
+      OptimizerFactory.setDefaultOptimizer("ASM");
+      testInlineWithWithLiteral();
   }
 
   public void testInlineWithWithLiteral2() {
@@ -422,7 +427,7 @@ public class WithTests extends AbstractTest {
   }
 
   public static class Recipients {
-    private List<Recipient> list = Collections.EMPTY_LIST;
+    private List<Recipient> list = Collections.emptyList();
 
     public void setRecipients(List<Recipient> recipients) {
       this.list = recipients;


### PR DESCRIPTION
Fixes #222 
The existing call to skipWhitespace() after the dot in captureToEOT() apparently attempted to skip the spaces after the dot but it didn't do anything since the cursor was not on a space. This meant that the following space ended the token (in the "default:" case of the next iteration).
The change is to skip the spaces after the dot, then go back by one position (since the loop will increment again in the while() instruction). Failing to decrement would break a bunch of tests using ".{" constructs. 