### PR TITLE
Issue226 Fix nested expression implementation

### DIFF
--- a/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/asm/ASMAccessorOptimizer.java
@@ -1555,7 +1555,7 @@ private Object optimizeFieldMethodProperty(Object ctx, String property, Class<?>
     if (ctx == null) return null;
 
     ExecutableStatement compiled = (ExecutableStatement) subCompileExpression(tk.toCharArray());
-    Object item = compiled.getValue(ctx, variableFactory);
+    Object item = compiled.getValue(this.ctx, variableFactory);
 
     ++cursor;
 

--- a/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/ReflectiveAccessorOptimizer.java
@@ -697,11 +697,6 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
         return getMethod(ctx, property);
       }
 
-      // if it is not already using this as context try to read the property value from this
-      if (ctx != this.thisRef && this.thisRef != null) {
-        addAccessorNode(new ThisValueAccessor());
-        return getBeanProperty(this.thisRef, property);
-      }
 
       if (ctx == null) {
         throw new PropertyAccessException("unresolvable property or identifier: " + property, expr, start, pCtx);
@@ -759,7 +754,7 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
     if (itemSubExpr) {
       try {
         idx = (itemStmt = (ExecutableStatement) subCompileExpression(item.toCharArray(), pCtx))
-            .getValue(ctx, thisRef, variableFactory);
+            .getValue(thisRef, thisRef, variableFactory);
       }
       catch (CompileException e) {
         e.setExpr(this.expr);
@@ -860,7 +855,7 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
     ExecutableStatement itemStmt = null;
     if (itemSubExpr) {
       idx = (itemStmt = (ExecutableStatement) subCompileExpression(item.toCharArray(), pCtx))
-          .getValue(ctx, thisRef, variableFactory);
+          .getValue(thisRef, thisRef, variableFactory);
     }
 
     ++cursor;
@@ -1006,7 +1001,6 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
     return getMethod(ctx, name, args, argTypes, es);
   }
 
-  @SuppressWarnings({"unchecked"})
   private Object getMethod(Object ctx, String name, Object[] args, Class[] argTypes, ExecutableStatement[] es) throws Exception {
     if (first && variableFactory != null && variableFactory.isResolveable(name)) {
       Object ptr = variableFactory.getVariableResolver(name).getValue();
@@ -1081,12 +1075,6 @@ public class ReflectiveAccessorOptimizer extends AbstractOptimizer implements Ac
       if ("size".equals(name) && args.length == 0 && cls.isArray()) {
         addAccessorNode(new ArrayLength());
         return getLength(ctx);
-      }
-
-      // if it is not already using this as context try to access the method this
-      if (ctx != this.thisRef && this.thisRef != null) {
-        addAccessorNode(new ThisValueAccessor());
-        return getMethod(this.thisRef, name, args, argTypes, es);
       }
 
       for (int i = 0; i < args.length; i++) {

--- a/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MapAccessorNest.java
+++ b/src/main/java/org/mvel2/optimizers/impl/refl/nodes/MapAccessorNest.java
@@ -51,10 +51,10 @@ public class MapAccessorNest implements AccessorNode {
 
   public Object getValue(Object ctx, Object elCtx, VariableResolverFactory vrf) {
     if (nextNode != null) {
-      return nextNode.getValue(((Map) ctx).get(property.getValue(ctx, elCtx, vrf)), elCtx, vrf);
+      return nextNode.getValue(((Map) ctx).get(property.getValue(elCtx, elCtx, vrf)), elCtx, vrf);
     }
     else {
-      return ((Map) ctx).get(property.getValue(ctx, elCtx, vrf));
+      return ((Map) ctx).get(property.getValue(elCtx, elCtx, vrf));
     }
   }
 


### PR DESCRIPTION
Fixes #226 
Main fix:
The previous way to evaluate expressions in square brackets using ThisValueAccessor had a serious side effect because it was using the map to the left as context rather than the object passed as "this". I'm reverting this and adding code to properly evaluate the sub-expression: Use thisRef to compile sub-expression in ReflectiveAccessorOptimizer and use elCtx rather than ctx in MapAccessorNest.

Also found that the fix for #181 had to be duplicated for cases where COMPILER_OPT_ALLOW_OVERRIDE_ALL_PROPHANDLING is set to true.