### PR TITLE
Allow literal conversion for backward compatibility. But don't conver…

### DIFF
--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -4209,6 +4209,7 @@ public class CoreConfidenceTests extends AbstractTest {
       put("b", 2);
     }});
     assertEquals(true, resultLeft);
+
     Serializable constantDoubleRight = MVEL.compileExpression("a / b < 0.99", parserContext);
     Object resultRight = MVEL.executeExpression(constantDoubleRight, new HashMap() {{
       put("a", 1);
@@ -4224,8 +4225,33 @@ public class CoreConfidenceTests extends AbstractTest {
       put("d", 2);
     }});
     assertEquals(true, resultRightInt);
-
   }
+
+  public void testNumberCoercion() {
+      final ParserContext parserContext = new ParserContext();
+      parserContext.setStrictTypeEnforcement(true);
+      parserContext.setStrongTyping(true);
+      parserContext.addInput("a", int.class);
+
+      // Long / Integer to Long / Long
+      Serializable longDivByInt = MVEL.compileExpression("15 * Math.round( new java.math.BigDecimal(\"49.4\") ) / 100", parserContext);
+      Object resultLongDivByInt = MVEL.executeExpression(longDivByInt, new HashMap());
+      assertEquals(7.35, resultLongDivByInt);
+
+      // Don't convert BigDecimal to int
+      Serializable intDivByBigDecimal = MVEL.compileExpression("a / new java.math.BigDecimal(\"0.5\")", parserContext);
+      Object resultIntDivByBigDecimal = MVEL.executeExpression(intDivByBigDecimal, new HashMap() {{
+          put("a", 10);
+      }});
+      assertEquals(20, ((BigDecimal)resultIntDivByBigDecimal).intValue());
+
+      // Don't convert Double to int
+      Serializable intDivByDouble = MVEL.compileExpression("a / 0.5", parserContext);
+      Object resultIntDivByDouble = MVEL.executeExpression(intDivByDouble, new HashMap() {{
+          put("a", 10);
+      }});
+      assertEquals(20, ((Double)resultIntDivByDouble).intValue());
+    }
 
   public void testUntypedClone() {
     String expression = "obj.clone();";


### PR DESCRIPTION
…t literals from float/double/BigDecimal to short/int/long/BigInteger

There were 2 commits around this logic.

https://github.com/mvel/mvel/commit/dd59667d693a776ca46bf61f3e19293f6913ee1f

  -> Allow conversion only when right is String. 
  -> But according to the added unit test CoreConfidenceTests#testPrimitiveNumberCoercionDuringDivisionShouldWorkOnBothSide(), the main motivation was to avoid coercion from Double to Integer.

https://github.com/mvel/mvel/commit/ee80e531

  -> Allow conversion when left is Float and right is Double

This PR is to loosen the conversion conditions for backward compatibility (See https://issues.redhat.com/browse/DROOLS-5051)

The logic is:

- If left is short/int/long/BigInteger and right is float/double/BigDecimal, don't convert. (= don't discard decimal type)
- else, you can convert.

I think this logic satisfies all the requirements.

Please review, thanks!