### PR TITLE
improve the performance of AbstractOptimizer

### DIFF
--- a/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
+++ b/src/main/java/org/mvel2/optimizers/AbstractOptimizer.java
@@ -22,8 +22,6 @@ import org.mvel2.MVEL;
 import org.mvel2.ParserContext;
 import org.mvel2.compiler.AbstractParser;
 
-import java.lang.reflect.Method;
-
 import static java.lang.Thread.currentThread;
 import static org.mvel2.util.ParseTools.*;
 
@@ -80,21 +78,15 @@ public class AbstractOptimizer extends AbstractParser {
                 if (MVEL.COMPILER_OPT_SUPPORT_JAVA_STYLE_CLASS_LITERALS && test.endsWith(".class"))
                     test = test.substring(0, test.length() - 6);
 
-                return Class.forName(test, true, classLoader);
+                return forNameCached(test, classLoader);
               } catch (ClassNotFoundException cnfe) {
                 try {
-                  return findInnerClass( test, classLoader, cnfe );
+                  return findInnerClassCached( test, classLoader, cnfe );
                 } catch (ClassNotFoundException e) { /* ignore */ }
-                Class cls = forNameWithInner(new String(expr, start, i - start), classLoader);
+                String className = new String(expr, start, i - start);
+                Class cls = forNameWithInnerCached(className, classLoader);
                 String name = new String(expr, i + 1, end - i - 1);
-                try {
-                  return cls.getField(name);
-                } catch (NoSuchFieldException nfe) {
-                  for (Method m : cls.getMethods()) {
-                    if (name.equals(m.getName())) return m;
-                  }
-                  return null;
-                }
+                return getFieldOrMethodCached(cls, className, name);
               }
             }
 


### PR DESCRIPTION
When I ran a test last night, I found that "AbstractOptimizer" spent too much time in Class.forName().
I use MVEL 2.0.17, but the latest code in github is almost same as v2.0.17.

I create this patch: cache Class.forName()/class.getField()/class.getMethod()'s result. They will not be changed in the JVM Runtime.

the origin code's test result:
```shell
# mvn test
Results :

Failed tests: 
  CoreConfidenceTests.testNumberCoercion:4338 expected:<7.35> but was:<7>

Tests run: 1140, Failures: 1, Errors: 0, Skipped: 0
```

my code's
```shell
# mvn test
Results :

Failed tests: 
  CoreConfidenceTests.testNumberCoercion:4338 expected:<7.35> but was:<7>
Tests in error: 
  CoreConfidenceTests.testInstanceofWithPackageImportAndInnerClass:4639 » Compile

Tests run: 1140, Failures: 1, Errors: 1, Skipped: 0
```

But I ran `CoreConfidenceTests.testInstanceofWithPackageImportAndInnerClass` in IDE, it passed.

I'm not sure it is correct, but I think it will be useful. So I decide to pull request, let anyone review it.

