### PR TITLE
Improve getBestCandidate() for BigDecimal args

### DIFF
--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -265,7 +265,7 @@ public class ParseTools {
               bestScore = score;
             }
             else if (score == bestScore) {
-              if (isMoreSpecialized(meth, bestCandidate) && !isVarArgs) {
+              if ((isMoreSpecialized(meth, bestCandidate) || isMorePreciseForBigDecimal(meth, bestCandidate, arguments))&& !isVarArgs) {
                 bestCandidate = meth;
               }
             }
@@ -307,6 +307,39 @@ public class ParseTools {
   private static boolean isMoreSpecialized( Method newCandidate, Method oldCandidate ) {
     return oldCandidate.getReturnType().isAssignableFrom( newCandidate.getReturnType()) &&
            oldCandidate.getDeclaringClass().isAssignableFrom( newCandidate.getDeclaringClass());
+  }
+
+  private static boolean isMorePreciseForBigDecimal(Method newCandidate, Method oldCandidate, Class[] arguments) {
+    Class<?>[] newParmTypes = newCandidate.getParameterTypes();
+    Class<?>[] oldParmTypes = oldCandidate.getParameterTypes();
+    int score = 0;
+    for (int i = 0; i != arguments.length; i++) {
+      Class<?> newParmType = newParmTypes[i];
+      Class<?> oldParmType = oldParmTypes[i];
+      if (arguments[i] != BigDecimal.class || !isNumeric(oldParmType) || !isNumeric(newParmType)) {
+        continue;
+      }
+      score += comparePrecision(unboxPrimitive(newParmType), unboxPrimitive(oldParmType));
+    }
+    return (score > 0);
+  }
+
+  private static int comparePrecision(Class<?> numeric1, Class<?> numeric2) {
+    if (numeric1 == numeric2) {
+      return 0;
+    }
+    if ((numeric1 == double.class) && (numeric2 == float.class || numeric2 == long.class || numeric2 == int.class || numeric2 == short.class)) {
+      return 1;
+    } else if ((numeric1 == float.class) && (numeric2 == long.class || numeric2 == int.class || numeric2 == short.class)) {
+      // float is preferred over long assuming users don't want to lose decimal part
+      return 1;
+    } else if ((numeric1 == long.class) && (numeric2 == int.class || numeric2 == short.class)) {
+      return 1;
+    } else if ((numeric1 == int.class) && numeric2 == short.class) {
+      return 1;
+    } else {
+      return -1;
+    }
   }
 
   private static int getMethodScore(Class[] arguments, boolean requireExact, Class<?>[] parmTypes, boolean varArgs) {

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -30,7 +30,7 @@ import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import junit.framework.TestCase;
-
+import org.junit.Assert;
 import org.mvel2.CompileException;
 import org.mvel2.DataConversion;
 import org.mvel2.MVEL;
@@ -4881,5 +4881,22 @@ public class CoreConfidenceTests extends AbstractTest {
       int hashCode = "foo". hashCode();
       Serializable s = MVEL.compileExpression(expr);
       assertEquals(Integer.valueOf(hashCode), MVEL.executeExpression(s));
+  }
+
+  public void testGetBestCandidateForBigDecimalArg() {
+    Class<?>[] arguments = new Class<?>[] {BigDecimal.class};
+    Method method = ParseTools.getBestCandidate(arguments, "round", Math.class, Math.class.getMethods(), true);
+    assertEquals(long.class, method.getReturnType());
+    Assert.assertArrayEquals(new Class<?>[] {double.class}, method.getParameterTypes());
+
+    arguments = new Class<?>[] {BigDecimal.class, BigDecimal.class};
+    method = ParseTools.getBestCandidate(arguments, "max", Math.class, Math.class.getMethods(), true);
+    assertEquals(double.class, method.getReturnType());
+    Assert.assertArrayEquals(new Class<?>[] {double.class, double.class}, method.getParameterTypes());
+
+    arguments = new Class<?>[] {BigDecimal.class, BigDecimal.class};
+    method = ParseTools.getBestCandidate(arguments, "scalb", Math.class, Math.class.getMethods(), true);
+    assertEquals(double.class, method.getReturnType());
+    Assert.assertArrayEquals(new Class<?>[] {double.class, int.class}, method.getParameterTypes());
   }
 }


### PR DESCRIPTION
- [DROOLS-5284] MVELTest.testTypeCoercionLongDivByInt fails with IBM JDK 8

See comment in https://issues.redhat.com/browse/DROOLS-5284

This PR adds isMorePreciseForBigDecimal() so Math.round(double) is prioritized over Math.round(float). This may not have to be specific to BigDecimal case but I wanted to keep the change minimal.
