### PR TITLE
Fix error message in `ClassCastException`

### DIFF
--- a/src/main/java/org/mvel2/ast/TypeCast.java
+++ b/src/main/java/org/mvel2/ast/TypeCast.java
@@ -86,7 +86,7 @@ public class TypeCast extends ASTNode {
       return inst;
     }
     else {
-      throw new ClassCastException(inst.getClass().getName() + " cannot be cast to: " + type.getClass().getName());
+      throw new ClassCastException(inst.getClass().getName() + " cannot be cast to: " + type.getName());
     }
   }
 


### PR DESCRIPTION
As it was written, the error message here would always say "cannot be cast to java.lang.Class", rather than referring to the actual target class name.

As a side note, I'm not sure why this is not just using `type.cast(inst)` instead of rewriting what I think is an equivalent check.