### PR TITLE
Issue182 constructor vararg support

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry kind="src" path="src/test/resources"/>
-	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
-		<accessrules>
-			<accessrule kind="accessible" pattern="javax/script/**"/>
-		</accessrules>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
-	<classpathentry kind="lib" path="C:/Users/luc/.m2/repository/junit/junit/4.8.2/junit-4.8.2.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
+++ b/src/test/java/org/mvel2/tests/core/CoreConfidenceTests.java
@@ -4899,4 +4899,18 @@ public class CoreConfidenceTests extends AbstractTest {
     assertEquals(double.class, method.getReturnType());
     Assert.assertArrayEquals(new Class<?>[] {double.class, int.class}, method.getParameterTypes());
   }
+  
+  public void testEmptyVarargConstructor() {
+      String clsName = MySet.class.getName();
+      OptimizerFactory.setDefaultOptimizer("ASM");
+      Serializable s = MVEL.compileExpression("new " + clsName + "()");
+      assertNotNull(MVEL.executeExpression(s));
+  }
+  
+  public void testEmptyVarargMethod() {
+    OptimizerFactory.setDefaultOptimizer("ASM");
+    Serializable s = MVEL.compileExpression("m.add()");
+    Map<String, MySet> inputs = Collections.singletonMap("m", new MySet());
+    MVEL.executeExpression(s, inputs);
+  }
 }


### PR DESCRIPTION
Fixes #182 
Fixed the vararg constructor issue by pushing an empty array of the correct type.
Also fixed a bug in the vararg method call but this was silently handled by switching to interpreted mode: The previous attempt to handle empty vararg would add an ExecutableLiteral as the last parameter but there is no support to add a constant of type array in  visitLdcInsn so we'd end up in the exception catch that switches to interpreted mode. I removed that code and instead added the empty array after looping (same solution as vararg constructor).
Also removed a couple of duplicate evaluations around the same code.
