### PR TITLE
Make constructor priority more consistent with method priority regarding vararg

### DIFF
--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
@@ -309,7 +310,7 @@ public class ParseTools {
            oldCandidate.getDeclaringClass().isAssignableFrom( newCandidate.getDeclaringClass());
   }
 
-  private static boolean isMorePreciseForBigDecimal(Method newCandidate, Method oldCandidate, Class[] arguments) {
+  private static boolean isMorePreciseForBigDecimal(Executable newCandidate, Executable oldCandidate, Class[] arguments) {
     Class<?>[] newParmTypes = newCandidate.getParameterTypes();
     Class<?>[] oldParmTypes = oldCandidate.getParameterTypes();
     int score = 0;
@@ -508,9 +509,14 @@ public class ParseTools {
       }
 
       int score = getMethodScore(arguments, requireExact, parmTypes, isVarArgs);
-      if (score != 0 && score > bestScore) {
-        bestCandidate = construct;
-        bestScore = score;
+      if (score != 0) {
+        if (score > bestScore) {
+          bestCandidate = construct;
+          bestScore = score;
+        }
+        else if (score == bestScore && (isMorePreciseForBigDecimal(construct, bestCandidate, arguments) || !isVarArgs)) {
+          bestCandidate = construct;
+        }
       }
     }
 

--- a/src/test/java/org/mvel2/tests/core/VarargTests.java
+++ b/src/test/java/org/mvel2/tests/core/VarargTests.java
@@ -1,0 +1,64 @@
+package org.mvel2.tests.core;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.mvel2.MVEL;
+import org.mvel2.optimizers.OptimizerFactory;
+
+public class VarargTests extends AbstractTest {
+  public static class MyVarargTestee {
+    private StringBuilder sb = new StringBuilder();
+    public MyVarargTestee() {
+    }
+    public MyVarargTestee(String arg) {
+      sb.append("singleArgCtor" + arg);
+    }
+    public MyVarargTestee(String ... arg) {
+      sb.append("multipleArgsCtor" + Arrays.asList(arg));
+    }
+    public void add(String arg) {
+      sb.append("singleArgMethod" + arg);
+    }
+    public void add(String ... arg) {
+      sb.append("multipleArgsMethod" + Arrays.asList(arg));
+    }
+    public String toString() {
+      return sb.toString();
+    }
+  }
+
+  public void testSingleArgMethodPreference() {
+    Serializable s = MVEL.compileExpression("testee.add('a')");
+    MyVarargTestee testee = new MyVarargTestee();
+    MVEL.executeExpression(s, Collections.singletonMap("testee", testee));
+    Assert.assertEquals("singleArgMethoda", testee.toString());
+  }
+
+  public void testVarargMethod() {
+      Serializable s = MVEL.compileExpression("testee.add('a', 'b')");
+      MyVarargTestee testee = new MyVarargTestee();
+      MVEL.executeExpression(s, Collections.singletonMap("testee", testee));
+      Assert.assertEquals("multipleArgsMethod[a, b]", testee.toString());
+  }
+
+  public void testNoArgCtorPreference() {
+      Serializable s = MVEL.compileExpression("new " + MyVarargTestee.class.getName() + "()");
+      MyVarargTestee result = (MyVarargTestee) MVEL.executeExpression(s);
+      Assert.assertEquals("", result.toString());
+  }
+
+  public void testSingleArgCtorPreference() {
+      Serializable s = MVEL.compileExpression("new " + MyVarargTestee.class.getName() + "('a')");
+      MyVarargTestee result = (MyVarargTestee) MVEL.executeExpression(s);
+      Assert.assertEquals("singleArgCtora", result.toString());
+  }
+
+  public void testVarargCtor() {
+      Serializable s = MVEL.compileExpression("new " + MyVarargTestee.class.getName() + "('a', 'b')");
+      MyVarargTestee result = (MyVarargTestee) MVEL.executeExpression(s);
+      Assert.assertEquals("multipleArgsCtor[a, b]", result.toString());
+  }
+}


### PR DESCRIPTION
Non-varargs constructor should have priority over varargs constructors having the same score. Also applied decimal precision priority.