### PR TITLE
[DROOLS-5937] Compound assignment operation like BigDecimal_type_prop…

### DIFF
--- a/src/main/java/org/mvel2/ast/DeepAssignmentNode.java
+++ b/src/main/java/org/mvel2/ast/DeepAssignmentNode.java
@@ -33,11 +33,11 @@ import static org.mvel2.util.ParseTools.*;
  * @author Christopher Brock
  */
 public class DeepAssignmentNode extends ASTNode implements Assignment {
-  private String property;
+  protected String property;
   // private char[] stmt;
 
-  private CompiledAccExpression acc;
-  private ExecutableStatement statement;
+  protected CompiledAccExpression acc;
+  protected ExecutableStatement statement;
 
   public DeepAssignmentNode(char[] expr, int start, int offset, int fields, int operation, String name, ParserContext pCtx) {
     super(pCtx);

--- a/src/main/java/org/mvel2/ast/DeepOperativeAssignmentNode.java
+++ b/src/main/java/org/mvel2/ast/DeepOperativeAssignmentNode.java
@@ -1,0 +1,48 @@
+/**
+ * MVEL 2.0
+ * Copyright (C) 2007 The Codehaus
+ * Mike Brock, Dhanji Prasanna, John Graham, Mark Proctor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel2.ast;
+
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.math.MathProcessor;
+
+import static org.mvel2.MVEL.eval;
+import static org.mvel2.PropertyAccessor.get;
+import static org.mvel2.PropertyAccessor.set;
+
+public class DeepOperativeAssignmentNode extends DeepAssignmentNode {
+
+    private final int operation;
+
+    public DeepOperativeAssignmentNode(char[] expr, int start, int offset, int fields, int operation, String name, ParserContext pCtx) {
+        super(expr, start, offset, fields, operation, name, pCtx);
+
+        this.operation = operation;
+    }
+
+    // No need to override DeepAssignmentNode.getReducedValueAccelerated() because it already works properly (calculate and assign).
+
+    @Override
+    public Object getReducedValue(Object ctx, Object thisValue, VariableResolverFactory factory) {
+        Object value = get(property, ctx, factory, thisValue, pCtx);
+        ctx = MathProcessor.doOperations(value, operation, eval(expr, start, offset, ctx, factory));
+        set(ctx, factory, property, ctx, pCtx);
+        return ctx;
+    }
+}

--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -32,6 +32,7 @@ import org.mvel2.ast.BooleanNode;
 import org.mvel2.ast.DeclProtoVarNode;
 import org.mvel2.ast.DeclTypedVarNode;
 import org.mvel2.ast.DeepAssignmentNode;
+import org.mvel2.ast.DeepOperativeAssignmentNode;
 import org.mvel2.ast.DoNode;
 import org.mvel2.ast.DoUntilNode;
 import org.mvel2.ast.EndOfStatement;
@@ -588,7 +589,7 @@ public class AbstractParser implements Parser, Serializable {
                     captureToEOS();
 
                     if (union) {
-                      return lastNode = new DeepAssignmentNode(expr, st = trimRight(st), trimLeft(cursor) - st, fields,
+                      return lastNode = new DeepOperativeAssignmentNode(expr, st = trimRight(st), trimLeft(cursor) - st, fields,
                           ADD, name, pCtx);
                     }
                     else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
@@ -633,8 +634,8 @@ public class AbstractParser implements Parser, Serializable {
                     captureToEOS();
 
                     if (union) {
-                      return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields,
-                          SUB, t, pCtx);
+                      return lastNode = new DeepOperativeAssignmentNode(expr, st = trimRight(st), trimLeft(cursor) - st, fields,
+                          SUB, name, pCtx);
                     }
                     else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
                       return lastNode = new IndexedOperativeAssign(expr, st, cursor - st,
@@ -683,8 +684,8 @@ public class AbstractParser implements Parser, Serializable {
                   captureToEOS();
 
                   if (union) {
-                    return lastNode = new DeepAssignmentNode(expr, st, cursor - st, fields,
-                        opLookup(op), t, pCtx);
+                    return lastNode = new DeepOperativeAssignmentNode(expr, st = trimRight(st), trimLeft(cursor) - st, fields,
+                        opLookup(op), name, pCtx);
                   }
                   else if (pCtx != null && (idx = pCtx.variableIndexOf(name)) != -1) {
                     return lastNode = new IndexedOperativeAssign(expr, st, cursor - st,

--- a/src/test/java/org/mvel2/tests/core/CompoundAssignmentOperatorTest.java
+++ b/src/test/java/org/mvel2/tests/core/CompoundAssignmentOperatorTest.java
@@ -1,0 +1,454 @@
+package org.mvel2.tests.core;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.mvel2.MVEL;
+import org.mvel2.tests.core.res.NumberHolder;
+
+public class CompoundAssignmentOperatorTest extends TestCase {
+
+    private static final String HOLDER = "holder";
+
+    private Map<String, Object> createVarMap() {
+        Map<String, Object> varMap = new HashMap<>();
+        NumberHolder holder = new NumberHolder();
+        holder.setIntPrimitive(120);
+        holder.setBigDecimal(new BigDecimal("120"));
+        varMap.put(HOLDER, holder);
+        varMap.put("myIntValue", 10);
+        varMap.put("myBigDecimalValue", 10);
+        return varMap;
+    }
+
+    @Test
+    public void testSimpleIntAddNum() {
+
+        String str = "simpleInteger += 10";
+
+        // eval test
+        Map<String, Object> varMap = new HashMap<>();
+        varMap.put("simpleInteger", new Integer(120));
+        Object result = MVEL.eval(str, varMap);
+
+        Integer simpleInteger = (Integer) varMap.get("simpleInteger");
+
+        assertEquals(130, result);
+        assertEquals(130, simpleInteger.intValue());
+
+        // compile test
+        varMap = new HashMap<>();
+        varMap.put("simpleInteger", new Integer(120));
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        simpleInteger = (Integer) varMap.get("simpleInteger");
+
+        assertEquals(130, result);
+        assertEquals(130, simpleInteger.intValue());
+    }
+
+    @Test
+    public void testIntAddNum() {
+
+        String str = "holder.intPrimitive += 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(130, result);
+        assertEquals(130, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(130, result);
+        assertEquals(130, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testIntSubNum() {
+
+        String str = "holder.intPrimitive -= 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(110, result);
+        assertEquals(110, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(110, result);
+        assertEquals(110, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testIntMultNum() {
+
+        String str = "holder.intPrimitive *= 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(1200, result);
+        assertEquals(1200, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(1200, result);
+        assertEquals(1200, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testIntDivNum() {
+
+        String str = "holder.intPrimitive /= 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(12.0, result);
+        assertEquals(12, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(12.0, result);
+        assertEquals(12, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testIntAddVar() {
+
+        String str = "holder.intPrimitive += myIntValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(130, result);
+        assertEquals(130, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(130, result);
+        assertEquals(130, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testIntSubVar() {
+
+        String str = "holder.intPrimitive -= myIntValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(110, result);
+        assertEquals(110, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(110, result);
+        assertEquals(110, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testIntMultVar() {
+
+        String str = "holder.intPrimitive *= myIntValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(1200, result);
+        assertEquals(1200, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(1200, result);
+        assertEquals(1200, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testIntDivVar() {
+
+        String str = "holder.intPrimitive /= myIntValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(12.0, result);
+        assertEquals(12, holder.getIntPrimitive());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(12.0, result);
+        assertEquals(12, holder.getIntPrimitive());
+    }
+
+    @Test
+    public void testBigDecimalAddNum() {
+
+        String str = "holder.bigDecimal += 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("130"), result);
+        assertEquals(new BigDecimal("130"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("130"), result);
+        assertEquals(new BigDecimal("130"), holder.getBigDecimal());
+    }
+
+    @Test
+    public void testBigDecimalSubNum() {
+
+        String str = "holder.bigDecimal -= 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("110"), result);
+        assertEquals(new BigDecimal("110"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("110"), result);
+        assertEquals(new BigDecimal("110"), holder.getBigDecimal());
+    }
+
+    @Test
+    public void testBigDecimalMultNum() {
+
+        String str = "holder.bigDecimal *= 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("1200"), result);
+        assertEquals(new BigDecimal("1200"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("1200"), result);
+        assertEquals(new BigDecimal("1200"), holder.getBigDecimal());
+    }
+
+    @Test
+    public void testBigDecimalDivNum() {
+
+        String str = "holder.bigDecimal /= 10";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("12"), result);
+        assertEquals(new BigDecimal("12"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("12"), result);
+        assertEquals(new BigDecimal("12"), holder.getBigDecimal());
+    }
+
+    @Test
+    public void testBigDecimalAddVar() {
+
+        String str = "holder.bigDecimal += myBigDecimalValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("130"), result);
+        assertEquals(new BigDecimal("130"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("130"), result);
+        assertEquals(new BigDecimal("130"), holder.getBigDecimal());
+    }
+
+    @Test
+    public void testBigDecimalSubVar() {
+
+        String str = "holder.bigDecimal -= myBigDecimalValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("110"), result);
+        assertEquals(new BigDecimal("110"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("110"), result);
+        assertEquals(new BigDecimal("110"), holder.getBigDecimal());
+    }
+
+    @Test
+    public void testBigDecimalMultVar() {
+
+        String str = "holder.bigDecimal *= myBigDecimalValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("1200"), result);
+        assertEquals(new BigDecimal("1200"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("1200"), result);
+        assertEquals(new BigDecimal("1200"), holder.getBigDecimal());
+    }
+
+    @Test
+    public void testBigDecimalDivVar() {
+
+        String str = "holder.bigDecimal /= myBigDecimalValue";
+
+        // eval test
+        Map<String, Object> varMap = createVarMap();
+        Object result = MVEL.eval(str, varMap);
+
+        NumberHolder holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("12"), result);
+        assertEquals(new BigDecimal("12"), holder.getBigDecimal());
+
+        // compile test
+        varMap = createVarMap();
+        Serializable s = MVEL.compileExpression(str);
+        result = MVEL.executeExpression(s, varMap);
+
+        holder = (NumberHolder) varMap.get(HOLDER);
+
+        assertEquals(new BigDecimal("12"), result);
+        assertEquals(new BigDecimal("12"), holder.getBigDecimal());
+    }
+}

--- a/src/test/java/org/mvel2/tests/core/res/NumberHolder.java
+++ b/src/test/java/org/mvel2/tests/core/res/NumberHolder.java
@@ -1,0 +1,27 @@
+package org.mvel2.tests.core.res;
+
+import java.math.BigDecimal;
+
+public class NumberHolder {
+
+    private int intPrimitive;
+
+    private BigDecimal bigDecimal;
+
+    public int getIntPrimitive() {
+        return intPrimitive;
+    }
+
+    public void setIntPrimitive(int intPrimitive) {
+        this.intPrimitive = intPrimitive;
+    }
+
+    public BigDecimal getBigDecimal() {
+        return bigDecimal;
+    }
+
+    public void setBigDecimal(BigDecimal bigDecimal) {
+        this.bigDecimal = bigDecimal;
+    }
+
+}


### PR DESCRIPTION
…erty <op> Numeric/BigDecimal_value causes an unexpected result or error in MVEL.

- Implement DeepOperativeAssignmentNode

Originally, there were just DeepAssignmentNode so it just assigned the value in getReducedValue(). So I added DeepOperativeAssignmentNode which extends DeepAssignmentNode and overrides getReducedValue().

Note that this fix is only for basic calculation written in CompoundAssignmentOperatorTest.java. For RHDM-1538, we will also need to fix DROOLS-5897.