### PR TITLE
Fix Issue #280

### DIFF
--- a/src/main/java/org/mvel2/MVELInterpretedRuntime.java
+++ b/src/main/java/org/mvel2/MVELInterpretedRuntime.java
@@ -240,12 +240,11 @@ public class MVELInterpretedRuntime extends AbstractParser {
       case TERNARY:
         if (!stk.popBoolean()) {
           stk.clear();
-
-          ASTNode tk;
-
-          for (; ; ) {
-            if ((tk = nextToken()) == null || tk.isOperator(Operator.TERNARY_ELSE))
-              break;
+          for (int embeddedLevel = 1; embeddedLevel > 0; ) {
+        	  ASTNode tk = nextToken();
+        	  if (tk == null) break;
+              if (tk.isOperator(Operator.TERNARY_ELSE)) --embeddedLevel;
+              if (tk.isOperator(Operator.TERNARY)) ++embeddedLevel;
           }
         }
 

--- a/src/main/java/org/mvel2/MVELRuntime.java
+++ b/src/main/java/org/mvel2/MVELRuntime.java
@@ -99,9 +99,12 @@ public class MVELRuntime {
 
           case TERNARY:
             if (!stk.popBoolean()) {
-              //noinspection StatementWithEmptyBody
-              while (tk.nextASTNode != null && !(tk = tk.nextASTNode).isOperator(TERNARY_ELSE)) ;
-            }
+                for (int embeddedLevel = 1; embeddedLevel > 0;) {
+              	  tk = tk.nextASTNode;
+              	  if (tk == null) break;
+              	  if (tk.isOperator(TERNARY_ELSE)) --embeddedLevel;
+              	  else if (tk.isOperator(TERNARY)) ++embeddedLevel;
+                }            }
             stk.clear();
             continue;
 

--- a/src/test/java/org/mvel2/tests/core/TernaryOpPriorityTest.java
+++ b/src/test/java/org/mvel2/tests/core/TernaryOpPriorityTest.java
@@ -1,0 +1,24 @@
+package org.mvel2.tests.core;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.mvel2.MVEL;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+
+public class TernaryOpPriorityTest extends TestCase {
+	public void testTernaryOperatorPriority_Interpreted () {
+		@SuppressWarnings("unused")
+		int javaResult = false ? true ? 9 : 5 : 1;
+		Integer mvelResult = MVEL.eval("false ? true ? 9 : 5 : 1", Integer.class);
+	    Assert.assertEquals(javaResult, mvelResult.intValue());
+	}
+	public void testTernaryOperatorPriority_Compiled () {
+		int javaResult = false ? true ? 9 : 5 : 1;
+		Serializable f = MVEL.compileExpression("false ? true ? 9 : 5 : 1");
+		Integer mvelResult = MVEL.executeExpression(f, Map.of(), Map.of(), Integer.class);
+	    Assert.assertEquals(javaResult, mvelResult.intValue());
+	}
+}


### PR DESCRIPTION
In the presence of multiple embedded ternary operator, the engine would proceed to the first appearance of ':' instead of the one belonging to the current expression. The modified implementation counts the number of ternary operators and proceed to the one making the counter go back to zero.