### PR TITLE
Issue282 - Build fails under Java 17 because of module access restrictions

### DIFF
--- a/src/main/java/org/mvel2/PropertyAccessor.java
+++ b/src/main/java/org/mvel2/PropertyAccessor.java
@@ -592,17 +592,23 @@ public class PropertyAccessor {
       }
 
       if (member instanceof Method) {
-        try {
-          return ((Method) member).invoke(ctx, EMPTYARG);
+        Method method = (Method) member;
+		try {
+          return method.invoke(ctx, EMPTYARG);
         }
         catch (IllegalAccessException e) {
+          // Try method from interface, this might be a public method from a private implementation
+          Method itfMethod = ParseTools.determineActualTargetMethod(method);
+          if (itfMethod != null) {
+            return itfMethod.invoke(ctx, EMPTYARG);
+          }
           synchronized (member) {
             try {
-              ((Method) member).setAccessible(true);
-              return ((Method) member).invoke(ctx, EMPTYARG);
+              method.setAccessible(true);
+              return method.invoke(ctx, EMPTYARG);
             }
             finally {
-              ((Method) member).setAccessible(false);
+              method.setAccessible(false);
             }
           }
         }


### PR DESCRIPTION
Fixes #282 
This fixes a case that can happen in real life (not just unit tests): When a getter is declared in an interface and implemented in a private class, invoking it will fail when running in Java 17+. This happens for example with Map.Entry.getKey() and Map.Entry.getValue(). If we find that the invokation failed and the method can be found in a parent interface, then call the method in the interface.