### PR TITLE
Add a defensive judgement of cursor

### DIFF
--- a/src/main/java/org/mvel2/CompileException.java
+++ b/src/main/java/org/mvel2/CompileException.java
@@ -113,6 +113,7 @@ public class CompileException extends RuntimeException {
 
   private CharSequence showCodeNearError(char[] expr, int cursor) {
     if (expr == null) return "Unknown";
+    if (cursor < 0) cursor = 0;
 
     int start = cursor - 20;
     int end = (cursor + 30);

--- a/src/test/java/org/mvel2/tests/core/CompileExceptionTest.java
+++ b/src/test/java/org/mvel2/tests/core/CompileExceptionTest.java
@@ -1,0 +1,15 @@
+package org.mvel2.tests.core;
+
+import org.mvel2.CompileException;
+
+public class CompileExceptionTest extends AbstractTest{
+    public void testNoExceptionThrownWhenCreatingCompileExceptionWithCursorLessThanZero() {
+        CompileException ex = new CompileException("Dummy message!", "Dummy expression!".toCharArray(), -1);
+        try {
+            ex.getMessage();
+            ex.toString();
+        } catch(StringIndexOutOfBoundsException oob) {
+            fail("Should not throw exception even if cursor is less than 0!");
+        }
+    }
+}


### PR DESCRIPTION
Hi, this PR is a solution for issue #312 .
When creating a CompileException, the input cursor might be less than 0, which leads to a StringIndexOutOfBoundException thrown when calling its toString() method. Since it can be hard for MVEL users to notice this potential throwing of exception, I think it might be the best way to just eliminate this possibility inside the MVEL code rather than letting users to catch it. This commit solves this by adding a defensive judgement to make it at least 0.