### PR TITLE
Fix parse tool cannot identify string escape

### DIFF
--- a/src/main/java/org/mvel2/util/ParseTools.java
+++ b/src/main/java/org/mvel2/util/ParseTools.java
@@ -1358,6 +1358,7 @@ public class ParseTools {
 
     if (type == term) {
       for (start++; start < end; start++) {
+        if (chars[start] == '\\') start = skipStringEscape(start);
         if (chars[start] == type) {
           return start;
         }
@@ -2255,5 +2256,9 @@ public class ParseTools {
       } catch (ClassNotFoundException e) { /* ignore */ }
     }
     throw cnfe;
+  }
+
+  private static int skipStringEscape(int cur) {
+    return cur + 2;
   }
 }

--- a/src/test/java/org/mvel2/tests/core/ParseToolsTest.java
+++ b/src/test/java/org/mvel2/tests/core/ParseToolsTest.java
@@ -1,0 +1,10 @@
+package org.mvel2.tests.core;
+
+import org.mvel2.util.ParseTools;
+
+public class ParseToolsTest extends AbstractTest{
+    public void testShouldIdentifyStringEscape() {
+        assertEquals("Should return the correct terminate index of the String literal!",
+            5, ParseTools.balancedCapture(new char[]{'"', 'a', '\\', '"', 'b', '"'}, 0, 6, '"'));
+    }
+}


### PR DESCRIPTION
Fix the bug mentioned in issue #315 . Full analysis can be checked in the issue's comments.