### PR TITLE
[DO-NOT-MERGE] [DROOLS-7245] Inconsistent behavior of null value with…

### DIFF
--- a/src/test/java/org/mvel2/tests/core/operators/ArithmeticTest.java
+++ b/src/test/java/org/mvel2/tests/core/operators/ArithmeticTest.java
@@ -1,0 +1,33 @@
+package org.mvel2.tests.core.operators;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class ArithmeticTest extends BaseOperatorTest {
+
+    public ArithmeticTest(Class type, String operator, boolean propertyOnLeft) {
+        super(type, operator, propertyOnLeft);
+    }
+
+    private static final String[] ARITHMETIC_OPERATORS = new String[]{"+", "-", "*", "/"};
+
+    @Parameters
+    public static Collection<Object[]> ruleParams() {
+        List<Object[]> parameterData = new ArrayList<Object[]>();
+        for (Class type : TYPES) {
+            for (String operator : ARITHMETIC_OPERATORS) {
+                for (boolean propertyOnLeft : PROPERTY_ON_LEFT)
+                    parameterData.add(new Object[]{type, operator, propertyOnLeft});
+            }
+        }
+
+        return parameterData;
+    }
+
+}

--- a/src/test/java/org/mvel2/tests/core/operators/BaseOperatorTest.java
+++ b/src/test/java/org/mvel2/tests/core/operators/BaseOperatorTest.java
@@ -1,0 +1,101 @@
+package org.mvel2.tests.core.operators;
+
+import java.beans.Introspector;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class BaseOperatorTest {
+
+    protected static final Class[] TYPES = new Class[]{Integer.class, Long.class, Byte.class, Character.class, Short.class, Float.class, Double.class, BigInteger.class, BigDecimal.class};
+    protected static final boolean[] PROPERTY_ON_LEFT = new boolean[]{true, false};
+
+    protected Class type;
+
+    protected String operator;
+
+    protected boolean propertyOnLeft;
+
+    protected String toStringTestParams() {
+        return "[" + type + ", " + operator + ", " + propertyOnLeft + "]";
+    }
+
+    public BaseOperatorTest(Class type, String operator, boolean propertyOnLeft) {
+        this.type = type;
+        this.operator = operator;
+        this.propertyOnLeft = propertyOnLeft;
+    }
+
+    @Test
+    public void operatorsWithNull() throws Exception {
+        String propertyName = getPropertyName(type);
+        String instanceValueString = getInstanceValueString(type);
+        String expression = "";
+        if (propertyOnLeft) {
+            expression += propertyName + " " + operator + " " + instanceValueString;
+        } else {
+            expression += instanceValueString + " " + operator + " " + propertyName;
+        }
+
+        System.out.println(expression);
+
+        Map<String, Object> imports = new HashMap<String, Object>();
+        imports.put(type.getSimpleName(), type);
+        ParserContext pctx = new ParserContext(imports, null, "testfile");
+        pctx.setStrictTypeEnforcement(true);
+        pctx.setStrongTyping(true);
+        pctx.addInput(propertyName, type);
+        pctx.addImport("BaseOperatorTest", BaseOperatorTest.class);
+
+        Serializable compiledExpr = MVEL.compileExpression(expression, pctx);
+
+        VariableResolverFactory factory = new MapVariableResolverFactory(new HashMap<String, Object>());
+        factory.createVariable(propertyName, null);
+
+        try {
+            Object result = MVEL.executeExpression(compiledExpr, null, factory);
+            System.out.println("  => result = " + result + " : " + toStringTestParams());
+            fail("Should throw NPE : " + toStringTestParams());
+        } catch (NullPointerException e) {
+            System.out.println("  => NPE is thrown");
+            assertTrue(true);
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected Exception", e);
+        }
+    }
+
+    protected static String getPropertyName(Class clazz) {
+        // returns a property name of ValueHolder class
+        return Introspector.decapitalize(clazz.getSimpleName()) + "Value";
+    }
+
+    protected static String getInstanceValueString(Class clazz) {
+        if (clazz.equals(Character.class)) {
+            return "BaseOperatorTest.constantCharacterValue()"; //// Mvel converts char to String so we cannot express Character constructor
+        } else {
+            return "new " + clazz.getSimpleName() + "(\"0\")";
+        }
+    }
+
+    protected static Throwable getRootCause(Throwable th) {
+        while (th.getCause() != null) {
+            th = th.getCause();
+        }
+        return th;
+    }
+
+    public static Character constantCharacterValue() {
+        return Character.valueOf('a');
+    }
+}

--- a/src/test/java/org/mvel2/tests/core/operators/EqualityComparisonNullCheckTest.java
+++ b/src/test/java/org/mvel2/tests/core/operators/EqualityComparisonNullCheckTest.java
@@ -1,0 +1,81 @@
+package org.mvel2.tests.core.operators;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class EqualityComparisonNullCheckTest extends BaseOperatorTest {
+
+    public EqualityComparisonNullCheckTest(Class type, String operator, boolean propertyOnLeft) {
+        super(type, operator, propertyOnLeft);
+    }
+
+    private static final String[] EQUALITY_COMPARISON_OPERATORS = new String[]{"==", "!="};
+
+    @Parameters
+    public static Collection<Object[]> ruleParams() {
+        List<Object[]> parameterData = new ArrayList<Object[]>();
+        for (Class type : TYPES) {
+            for (String operator : EQUALITY_COMPARISON_OPERATORS) {
+                for (boolean propertyOnLeft : PROPERTY_ON_LEFT)
+                    parameterData.add(new Object[]{type, operator, propertyOnLeft});
+            }
+        }
+
+        return parameterData;
+    }
+
+    @Test
+    public void operatorsWithNull() throws Exception {
+        String propertyName = getPropertyName(type);
+        String expression = "";
+        if (propertyOnLeft) {
+            expression += propertyName + " " + operator + " null";
+        } else {
+            expression += "null " + operator + " " + propertyName;
+        }
+
+        System.out.println(expression);
+
+        Map<String, Object> imports = new HashMap<String, Object>();
+        imports.put(type.getSimpleName(), type);
+        ParserContext pctx = new ParserContext(imports, null, "testfile");
+        pctx.setStrictTypeEnforcement(true);
+        pctx.setStrongTyping(true);
+        pctx.addInput(propertyName, type);
+        pctx.addImport("BaseOperatorTest", BaseOperatorTest.class);
+
+        Serializable compiledExpr = MVEL.compileExpression(expression, pctx);
+
+        VariableResolverFactory factory = new MapVariableResolverFactory(new HashMap<String, Object>());
+        factory.createVariable(propertyName, null);
+
+        try {
+            Object result = MVEL.executeExpression(compiledExpr, null, factory);
+            System.out.println("  => result = " + result + " : " + toStringTestParams());
+            if (operator.equals("==") && result.equals(true) || operator.equals("!=") && result.equals(false)) {
+                assertTrue(true);
+            } else {
+                fail("Wrong result");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unexpected Exception", e);
+        }
+    }
+}

--- a/src/test/java/org/mvel2/tests/core/operators/EqualityComparisonTest.java
+++ b/src/test/java/org/mvel2/tests/core/operators/EqualityComparisonTest.java
@@ -1,0 +1,32 @@
+package org.mvel2.tests.core.operators;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class EqualityComparisonTest extends BaseOperatorTest {
+
+    public EqualityComparisonTest(Class type, String operator, boolean propertyOnLeft) {
+        super(type, operator, propertyOnLeft);
+    }
+
+    private static final String[] EQUALITY_COMPARISON_OPERATORS = new String[]{"==", "!="};
+
+    @Parameters
+    public static Collection<Object[]> ruleParams() {
+        List<Object[]> parameterData = new ArrayList<Object[]>();
+        for (Class type : TYPES) {
+            for (String operator : EQUALITY_COMPARISON_OPERATORS) {
+                for (boolean propertyOnLeft : PROPERTY_ON_LEFT)
+                    parameterData.add(new Object[]{type, operator, propertyOnLeft});
+            }
+        }
+
+        return parameterData;
+    }
+}

--- a/src/test/java/org/mvel2/tests/core/operators/InequalityComparisonTest.java
+++ b/src/test/java/org/mvel2/tests/core/operators/InequalityComparisonTest.java
@@ -1,0 +1,32 @@
+package org.mvel2.tests.core.operators;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class InequalityComparisonTest extends BaseOperatorTest {
+
+    public InequalityComparisonTest(Class type, String operator, boolean propertyOnLeft) {
+        super(type, operator, propertyOnLeft);
+    }
+
+    private static final String[] INEQUALITY_COMPARISON_OPERATORS = new String[]{"<", ">", "<=", ">="};
+
+    @Parameters
+    public static Collection<Object[]> ruleParams() {
+        List<Object[]> parameterData = new ArrayList<Object[]>();
+        for (Class type : TYPES) {
+            for (String operator : INEQUALITY_COMPARISON_OPERATORS) {
+                for (boolean propertyOnLeft : PROPERTY_ON_LEFT)
+                    parameterData.add(new Object[]{type, operator, propertyOnLeft});
+            }
+        }
+
+        return parameterData;
+    }
+}

--- a/src/test/java/org/mvel2/tests/core/operators/ValueHolder.java
+++ b/src/test/java/org/mvel2/tests/core/operators/ValueHolder.java
@@ -1,0 +1,95 @@
+package org.mvel2.tests.core.operators;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class ValueHolder {
+
+    private Integer integerValue = null;
+    private Long longValue = null;
+    private Byte byteValue = null;
+    private Character characterValue = null;
+    private Short shortValue = null;
+    private Float floatValue = null;
+    private Double doubleValue = null;
+    private BigInteger bigIntegerValue = null;
+    private BigDecimal bigDecimalValue = null;
+
+    public ValueHolder() {}
+
+    public Integer getIntegerValue() {
+        return integerValue;
+    }
+
+    public void setIntegerValue(Integer integerValue) {
+        this.integerValue = integerValue;
+    }
+
+    public Long getLongValue() {
+        return longValue;
+    }
+
+    public void setLongValue(Long longValue) {
+        this.longValue = longValue;
+    }
+
+    public Byte getByteValue() {
+        return byteValue;
+    }
+
+    public void setByteValue(Byte byteValue) {
+        this.byteValue = byteValue;
+    }
+
+    public Character getCharacterValue() {
+        return characterValue;
+    }
+
+    public void setCharacterValue(Character characterValue) {
+        this.characterValue = characterValue;
+    }
+
+    public Short getShortValue() {
+        return shortValue;
+    }
+
+    public void setShortValue(Short shortValue) {
+        this.shortValue = shortValue;
+    }
+
+    public Float getFloatValue() {
+        return floatValue;
+    }
+
+    public void setFloatValue(Float floatValue) {
+        this.floatValue = floatValue;
+    }
+
+    public Double getDoubleValue() {
+        return doubleValue;
+    }
+
+    public void setDoubleValue(Double doubleValue) {
+        this.doubleValue = doubleValue;
+    }
+
+    public BigInteger getBigIntegerValue() {
+        return bigIntegerValue;
+    }
+
+    public void setBigIntegerValue(BigInteger bigIntegerValue) {
+        this.bigIntegerValue = bigIntegerValue;
+    }
+
+    public BigDecimal getBigDecimalValue() {
+        return bigDecimalValue;
+    }
+
+    public void setBigDecimalValue(BigDecimal bigDecimalValue) {
+        this.bigDecimalValue = bigDecimalValue;
+    }
+
+    public static Character constantCharacterValue() {
+        return Character.valueOf('a');
+    }
+}


### PR DESCRIPTION
… arithmetic and comparison operators

- Test case only

This PR is not to fix issues, but to note the test cases to cover Type [Integer, Long, Byte, Character, Short, Float, Double, BigInteger, BigDecimal], Operators [+, -, *, /] [==, !=] [<, >, <=, >=], Property on left or right. And to note the analysis:

Result (as of 2022-11-25, 2.4.15-SNAPSHOT):

* **ArithmeticTest** [+, -, *, /] calculating null property with 0 or 'a'

  - Most of types throw NPE. <= good

  - Only Byte and Character returns a result (e.g. null, 0null)  <= looks wrong, but Mvel seems to consider Byte and Character are not number (See `MathProcessor.doOperationsSameType`).

* **EqualityComparisonTest** [==, !=] comparing null property with 0 or 'a'.

  - Integer, Long, Short, Float, Double : If the property is on left, returns an expected result (true or false). If the property is on right, throws NPE.  <= NPE is bad. 

  - Byte, Character, BigDecimal : Regardless of property is on left or right, returns an expected result (true or false).

  - BigInteger : Regardless of property is on left or right, throws NPE  <= NPE is bad. 

* **EqualityComparisonNullCheckTest** [==, !=] comparing null property with null.

  - All types returns an expected result (true or false) <= good

* **InequalityComparisonTest** [<, >, <=, >=] comparing null property with 0 or 'a'

  - Integer, Long, Short, Float, Double, BigDecimal : Always returns false <= NEP should be the right behavior. But this is the majority at the moment...

  - Byte, Character : Always returns null (=> results in NPE in Drools MVELConstraint.evaluate())

  - BigInteger : Always throws NEP