### PR TITLE
[DROOLS-7327] NullPointerException in mvel MathProcessor with equalit…

### DIFF
--- a/src/main/java/org/mvel2/math/MathProcessor.java
+++ b/src/main/java/org/mvel2/math/MathProcessor.java
@@ -389,9 +389,9 @@ public strictfp class MathProcessor {
           case LETHAN:
             return val1 != null && val2 != null && toInteger(val1) <= toInteger(val2);
           case EQUAL:
-            return val1 == null ? val2 == null : toInteger(val1) == toInteger(val2);
+            return val1 != null && val2 != null ? toInteger(val1) == toInteger(val2) : val1 == val2;
           case NEQUAL:
-            return val1 == null ? val2 != null : toInteger(val1) != toInteger(val2);
+            return val1 != null && val2 != null ? toInteger(val1) != toInteger(val2) : val1 != val2;
           case BW_AND:
             if (val2 instanceof Long) return (Integer) val1 & (Long) val2;
             return (Integer) val1 & (Integer) val2;
@@ -438,9 +438,9 @@ public strictfp class MathProcessor {
           case LETHAN:
             return val1 != null && val2 != null && toShort(val1) <= toShort(val2);
           case EQUAL:
-            return val1 == null ? val2 == null : toShort(val1) == toShort(val2);
+            return val1 != null && val2 != null ? toShort(val1) == toShort(val2) : val1 == val2;
           case NEQUAL:
-            return val1 == null ? val2 != null : toShort(val1) != toShort(val2);
+            return val1 != null && val2 != null ? toShort(val1) != toShort(val2) : val1 != val2;
           case BW_AND:
             return (Short) val1 & (Short) val2;
           case BW_OR:
@@ -481,9 +481,9 @@ public strictfp class MathProcessor {
           case LETHAN:
             return val1 != null && val2 != null && toLong(val1) <= toLong(val2);
           case EQUAL:
-            return val1 == null ? val2 == null : toLong(val1) == toLong(val2);
+            return val1 != null && val2 != null ? toLong(val1) == toLong(val2) : val1 == val2;
           case NEQUAL:
-            return val1 == null ? val2 != null : toLong(val1) != toLong(val2);
+            return val1 != null && val2 != null ? toLong(val1) != toLong(val2) : val1 != val2;
           case BW_AND:
             if (val2 instanceof Integer) return (Long) val1 & (Integer) val2;
             return (Long) val1 & (Long) val2;
@@ -534,9 +534,9 @@ public strictfp class MathProcessor {
           case LETHAN:
             return val1 != null && val2 != null && toDouble(val1) <= toDouble(val2);
           case EQUAL:
-            return val1 == null ? val2 == null : toDouble(val1) == toDouble(val2);
+            return val1 != null && val2 != null ? toDouble(val1) == toDouble(val2) : val1 == val2;
           case NEQUAL:
-            return val1 == null ? val2 != null : toDouble(val1) != toDouble(val2);
+            return val1 != null && val2 != null ? toDouble(val1) != toDouble(val2) : val1 != val2;
           case BW_AND:
           case BW_OR:
           case BW_SHIFT_LEFT:
@@ -570,9 +570,9 @@ public strictfp class MathProcessor {
           case LETHAN:
             return val1 != null && val2 != null && toFloat(val1) <= toFloat(val2);
           case EQUAL:
-            return val1 == null ? val2 == null : toFloat(val1) == toFloat(val2);
+            return val1 != null && val2 != null ? toFloat(val1) == toFloat(val2) : val1 == val2;
           case NEQUAL:
-            return val1 == null ? val2 != null : toFloat(val1) != toFloat(val2);
+            return val1 != null && val2 != null ? toFloat(val1) != toFloat(val2) : val1 != val2;
           case BW_AND:
           case BW_OR:
           case BW_SHIFT_LEFT:
@@ -605,9 +605,9 @@ public strictfp class MathProcessor {
           case LETHAN:
             return ((BigInteger) val1).compareTo(((BigInteger) val2)) <= 0;
           case EQUAL:
-            return ((BigInteger) val1).compareTo(((BigInteger) val2)) == 0;
+            return val1 != null && val2 != null ? ((BigInteger) val1).compareTo(((BigInteger) val2)) == 0 : val1 == val2;
           case NEQUAL:
-            return ((BigInteger) val1).compareTo(((BigInteger) val2)) != 0;
+            return val1 != null && val2 != null ? ((BigInteger) val1).compareTo(((BigInteger) val2)) != 0 : val1 != val2;
           case BW_AND:
           case BW_OR:
           case BW_SHIFT_LEFT:

--- a/src/test/java/org/mvel2/tests/core/operators/BaseOperatorsTest.java
+++ b/src/test/java/org/mvel2/tests/core/operators/BaseOperatorsTest.java
@@ -1,0 +1,40 @@
+package org.mvel2.tests.core.operators;
+
+import java.beans.Introspector;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class BaseOperatorsTest {
+
+    protected static final Class[] TYPES = new Class[]{Integer.class, Long.class, Byte.class, Character.class, Short.class, Float.class, Double.class, BigInteger.class, BigDecimal.class};
+    protected static final boolean[] NULL_PROPERTY_ON_LEFT = new boolean[]{true, false};
+    protected static final String[] EQUALITY_COMPARISON_OPERATORS = new String[]{"==", "!="};
+
+    protected Class type;
+
+    protected String operator;
+
+    protected boolean nullPropertyOnLeft;
+
+    public BaseOperatorsTest(Class type, String operator, boolean nullPropertyOnLeft) {
+        this.type = type;
+        this.operator = operator;
+        this.nullPropertyOnLeft = nullPropertyOnLeft;
+    }
+
+    protected static String getPropertyName(Class clazz) {
+        return Introspector.decapitalize(clazz.getSimpleName()) + "Value";
+    }
+
+    protected static String getInstanceValueString(Class clazz) {
+        if (clazz.equals(Character.class)) {
+            return "BaseOperatorTest.constantCharacterValue()"; //// Mvel converts char to String so we cannot express Character constructor
+        } else {
+            return "new " + clazz.getSimpleName() + "(\"0\")";
+        }
+    }
+
+    public static Character constantCharacterValue() {
+        return Character.valueOf('a');
+    }
+}

--- a/src/test/java/org/mvel2/tests/core/operators/EqualityComparisonTest.java
+++ b/src/test/java/org/mvel2/tests/core/operators/EqualityComparisonTest.java
@@ -1,0 +1,73 @@
+package org.mvel2.tests.core.operators;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mvel2.MVEL;
+import org.mvel2.ParserContext;
+import org.mvel2.integration.VariableResolverFactory;
+import org.mvel2.integration.impl.MapVariableResolverFactory;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class EqualityComparisonTest extends BaseOperatorsTest {
+
+    public EqualityComparisonTest(Class type, String operator, boolean nullPropertyOnLeft) {
+        super(type, operator, nullPropertyOnLeft);
+    }
+
+    @Parameters
+    public static Collection<Object[]> ruleParams() {
+        List<Object[]> parameterData = new ArrayList<Object[]>();
+        for (Class type : TYPES) {
+            for (String operator : EQUALITY_COMPARISON_OPERATORS) {
+                for (boolean nullPropertyOnLeft : NULL_PROPERTY_ON_LEFT)
+                    parameterData.add(new Object[]{type, operator, nullPropertyOnLeft});
+            }
+        }
+
+        return parameterData;
+    }
+
+    @Test
+    public void compareWithNullProperty() throws Exception {
+        String propertyName = getPropertyName(type);
+        String instanceValueString = getInstanceValueString(type);
+        String expression = "";
+        if (nullPropertyOnLeft) {
+            expression += propertyName + " " + operator + " " + instanceValueString;
+        } else {
+            expression += instanceValueString + " " + operator + " " + propertyName;
+        }
+
+        Map<String, Object> imports = new HashMap<String, Object>();
+        imports.put(type.getSimpleName(), type);
+        ParserContext pctx = new ParserContext(imports, null, "testfile");
+        pctx.setStrictTypeEnforcement(true);
+        pctx.setStrongTyping(true);
+        pctx.addInput(propertyName, type);
+        pctx.addImport("BaseOperatorTest", BaseOperatorsTest.class);
+
+        Serializable compiledExpr = MVEL.compileExpression(expression, pctx);
+
+        VariableResolverFactory factory = new MapVariableResolverFactory(new HashMap<String, Object>());
+        factory.createVariable(propertyName, null);
+
+        Object result = MVEL.executeExpression(compiledExpr, null, factory);
+        if (operator.equals("==") && result.equals(false) || operator.equals("!=") && result.equals(true)) {
+            assertTrue(true);
+        } else {
+            fail("Wrong result");
+        }
+    }
+}


### PR DESCRIPTION
…y check when null property is on right side

This fix focuses on `==` and `!=`, because other comparisons (e.g. `>`) are valid to throw a NullPointerException.