### PR TITLE
[DROOLS-7428] ErrorUtil should not throw NPE

### DIFF
--- a/src/main/java/org/mvel2/util/ErrorUtil.java
+++ b/src/main/java/org/mvel2/util/ErrorUtil.java
@@ -13,6 +13,9 @@ public class ErrorUtil {
   private static final Logger LOG = Logger.getLogger(ErrorUtil.class.getName());
 
   public static CompileException rewriteIfNeeded(CompileException caught, char[] outer, int outerCursor) {
+    if (caught.getExpr() == null) {
+        return caught;
+    }
     if (outer != caught.getExpr()) {
       if (caught.getExpr().length <= caught.getCursor()) {
         caught.setCursor(caught.getExpr().length - 1);

--- a/src/test/java/org/mvel2/tests/core/FailureTests.java
+++ b/src/test/java/org/mvel2/tests/core/FailureTests.java
@@ -1,10 +1,12 @@
 package org.mvel2.tests.core;
 
+import java.io.Serializable;
+import java.util.HashMap;
+
 import org.mvel2.CompileException;
 import org.mvel2.MVEL;
 import org.mvel2.ParserContext;
-
-import java.util.HashMap;
+import org.mvel2.optimizers.OptimizerFactory;
 
 /**
  * Tests to ensure MVEL fails when it should.
@@ -191,4 +193,30 @@ public class FailureTests extends AbstractTest {
 
   }
 
+  public void testErrorUtilShouldNotThrowNPE() {
+    try {
+      OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
+      Serializable compiledExpression = MVEL.compileExpression("new org.mvel2.tests.core.FailureTests$Person()");
+      MVEL.executeExpression(compiledExpression);
+
+      fail("Should throw CompileException");
+    } catch (CompileException ce) {
+      assertTrue(ce.getMessage().contains("unable to find constructor"));
+    } catch (NullPointerException npe) {
+      fail("Should not throw NullPointerException");
+    } finally {
+      OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
+    }
+  }
+
+  public static class Person {
+
+      private String name;
+
+      public Person(String name) {
+          super();
+          this.name = name;
+      }
+
+  }
 }


### PR DESCRIPTION
https://kie.zulipchat.com/#narrow/stream/232678-jbpm/topic/WorkItemHandler

https://issues.redhat.com/browse/DROOLS-7428

The problem is that ErrorUtil throws NPE when `caught.getExpr()` is null, so the call cannot get the root cause of the `CompileException`.

It is reported for business-central, but this should be fixed for general use cases.