### PR TITLE
[DROOLS-7540] Coercion from Interger literal to BigDecimal bind variable

### DIFF
--- a/src/main/java/org/mvel2/integration/impl/ClassImportResolverFactory.java
+++ b/src/main/java/org/mvel2/integration/impl/ClassImportResolverFactory.java
@@ -59,7 +59,7 @@ public class ClassImportResolverFactory extends BaseVariableResolverFactory {
       nextFactory = new MapVariableResolverFactory(new HashMap());
     }
 
-    return nextFactory.createVariable(name, value);
+    return nextFactory.createVariable(name, value, type);
   }
 
   public Class addClass(Class clazz) {

--- a/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
+++ b/src/main/java/org/mvel2/integration/impl/IndexedVariableResolverFactory.java
@@ -75,6 +75,9 @@ public class IndexedVariableResolverFactory extends BaseVariableResolverFactory 
   public VariableResolver createVariable(String name, Object value, Class<?> type) {
     VariableResolver vr = getResolver(name);
     if (vr != null) {
+      if (vr instanceof SimpleSTValueResolver) {
+          ((SimpleSTValueResolver) vr).setStaticType(type);
+      }
       vr.setValue(value);
     }
     return vr;

--- a/src/main/java/org/mvel2/integration/impl/SimpleSTValueResolver.java
+++ b/src/main/java/org/mvel2/integration/impl/SimpleSTValueResolver.java
@@ -64,7 +64,7 @@ public class SimpleSTValueResolver implements VariableResolver {
     this.value = handleTypeCoercion(type, value);
   }
 
-  private static Object handleTypeCoercion(Class type, Object value) {
+  public static Object handleTypeCoercion(Class type, Object value) {
     if (type != null && value != null && value.getClass() != type) {
       if (!canConvert(type, value.getClass())) {
         throw new RuntimeException("cannot assign " + value.getClass().getName() + " to type: "

--- a/src/main/java/org/mvel2/util/SimpleVariableSpaceModel.java
+++ b/src/main/java/org/mvel2/util/SimpleVariableSpaceModel.java
@@ -4,7 +4,7 @@ import org.mvel2.integration.VariableResolver;
 import org.mvel2.integration.VariableResolverFactory;
 import org.mvel2.integration.impl.IndexVariableResolver;
 import org.mvel2.integration.impl.IndexedVariableResolverFactory;
-import org.mvel2.integration.impl.SimpleValueResolver;
+import org.mvel2.integration.impl.SimpleSTValueResolver;
 
 /**
  * @author Mike Brock .
@@ -18,7 +18,7 @@ public class SimpleVariableSpaceModel extends VariableSpaceModel {
     VariableResolver[] resolvers = new VariableResolver[allVars.length];
     for (int i = 0; i < resolvers.length; i++) {
       if (i >= vals.length) {
-        resolvers[i] = new SimpleValueResolver(null);
+        resolvers[i] = new SimpleSTValueResolver(null, null);
       }
       else {
         resolvers[i] = new IndexVariableResolver(i, vals);


### PR DESCRIPTION
https://issues.redhat.com/browse/DROOLS-7540

This is a fix to solve test cases in https://github.com/kiegroup/drools/pull/5498

Drools uses `SimpleVariableSpaceModel` to create `IndexedVariableResolverFactory`. What this PR does are

* Use `SimpleSTValueResolver` instead of `SimpleValueResolver` to enable coercion
* Enhance `IndexVariableResolver` to enable coercion
