### PR TITLE
[mvel-359] Upgrade xstream to 1.4.20 for CVE-2022-41966 and CVE-2022-40151

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.19</version>
+            <version>1.4.20</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
https://github.com/mvel/mvel/issues/359