### PR TITLE
[mvel-359] xstream CVEs -- remove xstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,13 +290,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-            <version>1.4.19</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <distributionManagement>

--- a/src/test/java/org/mvel2/marshalling/MarshallingTest.java
+++ b/src/test/java/org/mvel2/marshalling/MarshallingTest.java
@@ -25,8 +25,6 @@ import org.mvel2.integration.impl.MapVariableResolverFactory;
 import org.mvel2.tests.BaseMvelTestCase;
 import org.mvel2.util.StringAppender;
 
-// import com.thoughtworks.xstream.XStream;
-
 /**
  * Generates templates to marshaller classes.
  * TODO
@@ -464,34 +462,6 @@ public class MarshallingTest extends BaseMvelTestCase {
   }
 
   private static final int COUNT = 0;
-
-//    public void testXStream() {
-//        XStream xstream = new XStream();
-//
-//        // run once to allow for caching
-//        Object data1 = getData();
-//        String str = xstream.toXML( data1 );
-//        System.out.println( str );
-//        Object data2 = xstream.fromXML( str );
-//        assertNotSame( data1,
-//                       data2 );
-//        assertEquals( data1,
-//                      data2 );
-//
-//        long start = System.currentTimeMillis();
-//        for ( int i = 0; i < COUNT; i++ ) {
-//            data1 = getData();
-//            str = xstream.toXML( data1 );
-//            data2 = xstream.fromXML( str );
-//            assertNotSame( data1,
-//                           data2 );
-//            assertEquals( data1,
-//                          data2 );
-//        }
-//        long end = System.currentTimeMillis();
-//
-//        System.out.println( "xstream : " + (end - start) );
-//    }
 
   public void testMVEL() throws Exception {
     Marshaller marshaller = new Marshaller();


### PR DESCRIPTION
- Actually, xstream is not used, so we can remove it

xstream seemed to be experimented in the past. But finally, removed from the code base. Just the pom dependency and commented-out codes remain now.

## Issue
- https://github.com/mvel/mvel/issues/359