### PR TITLE
Fix return type handling in PropertyVerifier

### DIFF
--- a/src/main/java/org/mvel2/compiler/PropertyVerifier.java
+++ b/src/main/java/org/mvel2/compiler/PropertyVerifier.java
@@ -247,7 +247,7 @@ public class PropertyVerifier extends AbstractOptimizer {
         || (Map.class.isAssignableFrom(ctx) && (switchStateReg = true)))) {
       Type parm = pCtx.getLastTypeParameters()[switchStateReg ? 1 : 0];
       pCtx.setLastTypeParameters(null);
-      return parm instanceof ParameterizedType ? Object.class : (Class) parm;
+      return parm instanceof Class ? (Class) parm : Object.class;
     }
 
     if (pCtx != null && "length".equals(property) && ctx.isArray()) {


### PR DESCRIPTION
Caused by: java.lang.ClassCastException: class sun.reflect.generics.reflectiveObjects.TypeVariableImpl cannot be cast to class java.lang.Class (sun.reflect.generics.reflectiveObjects.TypeVariableImpl and java.lang.Class are in module java.base of loader 'bootstrap')
	at org.mvel2.compiler.PropertyVerifier.getBeanProperty(PropertyVerifier.java:250)
	at org.mvel2.compiler.PropertyVerifier.analyze(PropertyVerifier.java:133)
	at org.mvel2.compiler.ExpressionCompiler.verify(ExpressionCompiler.java:400)
	at org.mvel2.compiler.ExpressionCompiler._compile(ExpressionCompiler.java:282)
	at org.mvel2.util.ParseTools.subCompileExpression(ParseTools.java:2131)
	at org.mvel2.ast.ReturnNode.<init>(ReturnNode.java:41)
	at org.mvel2.compiler.AbstractParser.nextToken(AbstractParser.java:423)
	at org.mvel2.compiler.ExpressionCompiler._compile(ExpressionCompiler.java:127)
	at org.mvel2.MVEL.compileExpression(MVEL.java:832)
	at org.mvel2.templates.res.CompiledExpressionNode.<init>(CompiledExpressionNode.java:41)
	at org.mvel2.templates.TemplateCompiler.compileFrom(TemplateCompiler.java:211)