### PR TITLE
Enhance java coverage: switchExpression etc.

### DIFF
--- a/src/main/java/org/mvel3/parser/antlr4/Mvel3ToJavaParserVisitor.java
+++ b/src/main/java/org/mvel3/parser/antlr4/Mvel3ToJavaParserVisitor.java
@@ -81,6 +81,7 @@ import com.github.javaparser.ast.stmt.LabeledStmt;
 import com.github.javaparser.ast.stmt.SynchronizedStmt;
 import com.github.javaparser.ast.stmt.YieldStmt;
 import com.github.javaparser.ast.stmt.ContinueStmt;
+import com.github.javaparser.ast.stmt.EmptyStmt;
 import com.github.javaparser.ast.stmt.DoStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
 import com.github.javaparser.ast.stmt.ForEachStmt;
@@ -1449,6 +1450,11 @@ public class Mvel3ToJavaParserVisitor extends Mvel3ParserBaseVisitor<Node> {
             ExpressionStmt exprStmt = new ExpressionStmt(switchExpr);
             exprStmt.setTokenRange(createTokenRange(ctx));
             return exprStmt;
+        } else if (ctx.SEMI() != null) {
+            // Handle empty statement: SEMI (bare ';')
+            EmptyStmt emptyStmt = new EmptyStmt();
+            emptyStmt.setTokenRange(createTokenRange(ctx));
+            return emptyStmt;
         }
         // For now, fall back to default behavior
         return visitChildren(ctx);

--- a/src/test/java/org/mvel3/parser/antlr4/Antlr4MvelParserJavaParserASTTest.java
+++ b/src/test/java/org/mvel3/parser/antlr4/Antlr4MvelParserJavaParserASTTest.java
@@ -41,6 +41,7 @@ import com.github.javaparser.ast.stmt.YieldStmt;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.BreakStmt;
 import com.github.javaparser.ast.stmt.ContinueStmt;
+import com.github.javaparser.ast.stmt.EmptyStmt;
 import com.github.javaparser.ast.stmt.SwitchEntry;
 import com.github.javaparser.ast.stmt.ThrowStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
@@ -580,6 +581,16 @@ class Antlr4MvelParserJavaParserASTTest {
         assertThat(result.getResult().get().getStatement(0).isExpressionStmt()).isTrue();
         Expression switchExpr = result.getResult().get().getStatement(0).asExpressionStmt().getExpression();
         assertThat(switchExpr).isInstanceOf(SwitchExpr.class);
+    }
+
+    @Test
+    void testEmptyStatement() {
+        String block = "{ ; }";
+        Antlr4MvelParser parser = new Antlr4MvelParser();
+        ParseResult<BlockStmt> result = parser.parseBlock(block);
+        assertThat(result.getResult()).isPresent();
+
+        assertThat(result.getResult().get().getStatement(0)).isInstanceOf(EmptyStmt.class);
     }
 
     @Test


### PR DESCRIPTION
- `#ExpressionSwitch` / `switchExpression` — `visitExpressionSwitch` / `visitSwitchExpression` with `processSwitchLabeledRule` (arrow syntax, multiple labels, block/expression/throws outcomes)
- `explicitGenericInvocation` in `#MemberReferenceExpression` — `expr.<Type>method(args)` with type arguments
- `nonWildcardTypeArguments` in `primary` — `<Type>method(args)` generic method call without scope
- `classBody?` in `classCreatorRest` — Anonymous classes `new Runnable() { ... }` via `parseAnonymousClassBody`
- `innerCreator` in `#MemberReferenceExpression` — `expr.new Inner(args)` with type arguments and diamond operator
- `superSuffix` in `#MemberReferenceExpression` — `expr.super.method(args)`, `expr.super.field`, `expr.super(args)`
- `ASSERT expression (':' expression)? ';'` — `AssertStmt` with optional message expression
- `SYNCHRONIZED parExpression block` — `SynchronizedStmt` with lock expression and block body
- `YIELD expression ';'` — `YieldStmt` for Java 17 yield in switch
- `identifierLabel ':' statement` — `LabeledStmt` with label name and inner statement
- `SEMI` — `EmptyStmt` for bare semicolons