### PR TITLE
Add regression test for compiled boolean literal precedence

### DIFF
--- a/src/test/java/org/mvel2/tests/core/LiteralBooleanPrecedenceTest.java
+++ b/src/test/java/org/mvel2/tests/core/LiteralBooleanPrecedenceTest.java
@@ -1,0 +1,15 @@
+package org.mvel2.tests.core;
+
+import org.junit.Test;
+import org.mvel2.MVEL;
+
+import static org.junit.Assert.assertEquals;
+
+public class LiteralBooleanPrecedenceTest {
+
+    @Test
+    public void testCompiledBooleanLiteralPrecedence() {
+        String expr = "true && false && false || true";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+}


### PR DESCRIPTION
Related to #417

Adds a regression test for incorrect compiled evaluation of boolean literal expressions.

Example:
`true && false && false || true`

According to standard boolean operator precedence, where `&&` has higher precedence than `||`, this expression should evaluate to `true`, but compiled evaluation returns `false`.

From debugging, the issue appears to be in the compiled path, likely in `ExpressionCompiler._compile()` during literal reduction/grouping of mixed `&&` / `||` expressions.