### PR TITLE
[mvel-417] MVEL2: compileExpression returns wrong result for boolean literal expression

### DIFF
--- a/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
+++ b/src/main/java/org/mvel2/compiler/ExpressionCompiler.java
@@ -170,6 +170,7 @@ public class ExpressionCompiler extends AbstractParser {
              * reduction.
              */
             if ((tkLA = nextTokenSkipSymbols()) != null && tkLA.isLiteral()
+                && !isBooleanOperator(tkOp.getOperator())
                 && tkOp.getOperator() < 34 && ((lastOp == -1
                 || (lastOp < PTABLE.length && PTABLE[lastOp] < PTABLE[tkOp.getOperator()])))) {
               stk.push(tk.getLiteralValue(), tkLA.getLiteralValue(), op = tkOp.getOperator());

--- a/src/test/java/org/mvel2/tests/core/LiteralBooleanPrecedenceTest.java
+++ b/src/test/java/org/mvel2/tests/core/LiteralBooleanPrecedenceTest.java
@@ -1,0 +1,15 @@
+package org.mvel2.tests.core;
+
+import org.junit.Test;
+import org.mvel2.MVEL;
+
+import static org.junit.Assert.assertEquals;
+
+public class LiteralBooleanPrecedenceTest {
+
+    @Test
+    public void testCompiledBooleanLiteralPrecedence() {
+        String expr = "true && false && false || true";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+}

--- a/src/test/java/org/mvel2/tests/core/LiteralBooleanPrecedenceTest.java
+++ b/src/test/java/org/mvel2/tests/core/LiteralBooleanPrecedenceTest.java
@@ -3,13 +3,128 @@ package org.mvel2.tests.core;
 import org.junit.Test;
 import org.mvel2.MVEL;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 
 public class LiteralBooleanPrecedenceTest {
 
+    // --- Cases from issue #417 ---
+
     @Test
     public void testCompiledBooleanLiteralPrecedence() {
+        // ((true && false && false) || true) == true
         String expr = "true && false && false || true";
         assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testTrueOrTrueAndFalse() {
+        // (true || (true && false)) == true
+        String expr = "true || true && false";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testTrueOrFalseAndFalse() {
+        // (true || (false && false)) == true
+        String expr = "true || false && false";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    // --- Additional precedence cases ---
+
+    @Test
+    public void testFalseOrTrueAndTrue() {
+        // (false || (true && true)) == true
+        String expr = "false || true && true";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testFalseAndTrueOrTrue() {
+        // ((false && true) || true) == true
+        String expr = "false && true || true";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testFalseOrFalseAndFalseOrTrue() {
+        // (false || (false && false) || true) == true
+        String expr = "false || false && false || true";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testTrueAndTrueOrFalseAndFalse() {
+        // ((true && true) || (false && false)) == true
+        String expr = "true && true || false && false";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testFalseAndFalseOrFalseAndFalse() {
+        // ((false && false) || (false && false)) == false
+        String expr = "false && false || false && false";
+        assertEquals(false, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testAllAndShouldBeTrue() {
+        // (true && true && true) == true
+        String expr = "true && true && true";
+        assertEquals(true, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    @Test
+    public void testAllOrShouldBeFalse() {
+        // (false || false || false) == false
+        String expr = "false || false || false";
+        assertEquals(false, MVEL.executeExpression(MVEL.compileExpression(expr)));
+    }
+
+    // --- Verify compiled literals match interpreted eval ---
+
+    @Test
+    public void testCompiledMatchesInterpreted() {
+        String[] expressions = {
+            "true && false && false || true",
+            "true || true && false",
+            "true || false && false",
+            "false || true && true",
+            "false && true || true",
+            "false || false && false || true",
+            "true && true || false && false",
+            "false && false || false && false"
+        };
+        for (String expr : expressions) {
+            Object interpreted = MVEL.eval(expr);
+            Object compiled = MVEL.executeExpression(MVEL.compileExpression(expr));
+            assertEquals("Mismatch for: " + expr, interpreted, compiled);
+        }
+    }
+
+    // --- Verify compiled literals match variable-based evaluation ---
+
+    @Test
+    public void testCompiledLiteralsMatchVariables() {
+        Map<String, Object> vars = new HashMap<String, Object>();
+        vars.put("T", true);
+        vars.put("F", false);
+
+        String[][] pairs = {
+            {"true && false && false || true",    "T && F && F || T"},
+            {"true || true && false",             "T || T && F"},
+            {"true || false && false",            "T || F && F"},
+            {"false || true && true",             "F || T && T"},
+            {"false && true || true",             "F && T || T"},
+            {"true && true || false && false",    "T && T || F && F"},
+        };
+        for (String[] pair : pairs) {
+            Object literal = MVEL.executeExpression(MVEL.compileExpression(pair[0]));
+            Object variable = MVEL.executeExpression(MVEL.compileExpression(pair[1]), vars);
+            assertEquals("Mismatch for: " + pair[0], variable, literal);
+        }
     }
 }


### PR DESCRIPTION
- Additional tests on top of https://github.com/mvel/mvel/pull/419
- Fix ExpressionCompiler.java

The compile-time literal reduction in ExpressionCompiler._compile() was
folding boolean literals left-to-right without respecting that && binds
tighter than ||. For example, "true || true && false" would reduce
"true || true" first, producing false instead of true.

Skip literal reduction for boolean operators (AND/OR) so these
expressions flow through the existing second-pass optimization in
CompilerTools, which already builds And/Or node trees with correct
precedence.

Skipping the reduction path is simpler and robust than changing the reduction logic to meet the precedence. So I chose this approach.