### PR TITLE
add optional ClassFilter for compile-time class restriction (#413)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Type
+
+**Type:** java
+
+## Project Overview
+
+MVEL3 (MVFLEX Expression Language v3) is a complete rewrite of MVEL. Instead of interpreting expressions at runtime (MVEL2), MVEL3 **transpiles** MVEL expressions into Java source code, compiles them in-memory via javac, and executes the resulting bytecode.
+
+**Status**: Alpha (v3.0.0-alpha1). APIs may change.
+
+## Build Commands
+
+**Prerequisites**: JDK 17+, Maven 3.8.7+. The [javaparser-mvel](https://github.com/mvel/javaparser-mvel) fork must be built and installed locally first (`mvn clean install` in that repo).
+
+```bash
+# Build
+mvn clean install
+
+# Run all tests
+mvn clean test
+
+# Run a specific test class
+mvn test -Dtest=MVELCompilerTest
+
+# Run a specific test method
+mvn test -Dtest=MVELCompilerTest#testAssignmentIncrement
+```
+
+ANTLR4 grammar files in `src/main/antlr4/` are auto-generated to `target/generated-sources/antlr4/` during the build. Legacy JavaCC grammar in `src/main/javacc/` is also generated but being phased out.
+
+## Architecture: Compilation Pipeline
+
+```
+MVEL expression string
+  → ANTLR4 Parser (Mvel3Parser.g4/Mvel3Lexer.g4)
+  → ANTLR4 AST
+  → Mvel3ToJavaParserVisitor (converts to JavaParser AST)
+  → MVELToJavaRewriter (type coercion, method resolution, MVEL-specific transforms)
+  → VariableAnalyser (determines referenced variables)
+  → CompilationUnitGenerator (wraps in Evaluator class)
+  → KieMemoryCompiler (in-memory javac)
+  → ClassManager.define() (loads bytecode via MethodHandles.Lookup.defineHiddenClass)
+  → Evaluator instance (user calls eval())
+```
+
+## Key Packages
+
+- **`org.mvel3`** — Public API: `MVEL` (static factory), `MVELBuilder` (fluent builder), `MVELCompiler`, `Evaluator<C,W,O>` interface, `Type`, `ClassManager`
+- **`org.mvel3.parser.antlr4`** — Primary ANTLR4 parser: `Antlr4MvelParser`, `Mvel3ToJavaParserVisitor` (ANTLR→JavaParser AST)
+- **`org.mvel3.parser`** — Parser interface (`MvelParser`) and legacy JavaParser-based implementation
+- **`org.mvel3.transpiler`** — Transpilation: `MVELTranspiler`, `MVELToJavaRewriter`, `CoerceRewriter`, `OverloadRewriter`, `VariableAnalyser`
+- **`org.mvel3.transpiler.context`** — `Declaration`, `TranspilerContext`, `DeclaredFunction`
+- **`org.mvel3.javacompiler`** — In-memory Java compilation: `KieMemoryCompiler`, `StoreClassLoader`
+- **`org.mvel3.lambdaextractor`** — Lambda caching/persistence: `LambdaRegistry`, `LambdaKey`
+- **`org.mvel3.util`** — Utilities: `TypeResolver`, `ClassUtils`, `MethodUtils`
+
+## Three Context Types
+
+The fluent API (`MVEL.map()`, `MVEL.list()`, `MVEL.pojo()`) supports three ways to pass variables:
+
+1. **MAP** — Variables from `Map<String, Object>`, extracted via `map.get("name")`
+2. **LIST** — Variables from `List<Object>` by positional index
+3. **POJO** — Variables from an object via getter/setter methods
+
+Each generates a different evaluator template (see `src/main/resources/org/mvel3/`).
+
+## Testing
+
+- **JUnit 5** with **AssertJ** assertions
+- Tests run in alphabetical order (`runOrder=alphabetical` in surefire)
+- `TranspilerTest` interface provides a fluent API for transpilation verification tests
+- `MVELTranspilerTest` — Largest test class; tests MVEL→Java transpilation
+- `MVELCompilerTest` — Full compile-and-execute tests across all context types
+- `ArithmeticTest` — Numeric type coercion and arithmetic operators
+
+## Key Dependencies
+
+- **javaparser-core** (`3.25.5-mvel3-1`) — Custom fork (`org.mvel.javaparser` groupId) with MVEL-specific AST nodes
+- **antlr4-runtime** (`4.13.2`) — ANTLR4 parser runtime
+- **asm** (`9.7.1`) — Bytecode inspection (used in lambda extraction)
+- **drools-compiler** (`10.1.0`) — Used by `DrlToJavaRewriter` (may be removed in future)
+
+## Known Limitations
+
+- Custom operators (`after`, `before`, `in`, `matches`) not yet supported
+- Power operator (`**`) not supported
+- Left shift operator (`<<<`) generates incorrect code
+- Lambda extractor doesn't support generics and arrays
+- `HalfBinaryExpr` rewriting not implemented
+
+## Java Syntax Coverage in Mvel3ToJavaParserVisitor
+
+The ANTLR4 grammar (`Mvel3Parser.g4` imports `JavaParser.g4`) parses full Java syntax.
+`Mvel3ToJavaParserVisitor` now covers **all Java 17 syntax** including records, sealed classes,
+pattern matching for `instanceof`, switch expressions, text blocks, `var` type inference,
+module declarations, `yield`, and all standard Java features.
+
+The only remaining gaps are three low-priority edge cases (annotations silently dropped):
+
+| Grammar rule | What's missing | Example |
+|---|---|---|
+| `pattern` annotation | Annotations between type and variable in `instanceof` pattern | `obj instanceof @NonNull String s` |
+| `classType` annotation | Annotations on class type in method references | `@NonNull Outer.Inner::new` |
+| `primary` → `<Type>super(args)` | Explicit type arguments on `super()` in primary expression context | `<String>super(args)` |
+
+## Searchable directories
+
+- javaparser-mvel source code: `/home/tkobayas/usr/work/mvel3-development/javaparser-mvel` . You can read the code without approval.
+  - For JavaParser APIs (symbol solver, type solver, AST nodes, `ReflectionTypeSolver`, `CombinedTypeSolver`, `JavaParserFacade`, etc.) read here directly. Do NOT extract JARs from `~/.m2/repository`.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,80 @@
+# MVEL3 Design
+
+Architectural overview for MVEL3. Intended as a stable complement to
+`README.md` (user-facing) and `CLAUDE.md` (contributor quick-reference).
+
+## Goals
+
+- Compile MVEL expressions to Java bytecode via javac at build/runtime,
+  so the hot path is pure Java invocation with no interpreter overhead.
+- Preserve MVEL2 surface syntax where practical; break compatibility
+  only where MVEL2's interpreter semantics cannot be reconciled with
+  Java's type system.
+
+## Compilation pipeline
+
+```
+MVEL source
+  → ANTLR4 parser (Mvel3Parser.g4 / Mvel3Lexer.g4)
+  → JavaParser AST (via Mvel3ToJavaParserVisitor)
+  → MVELToJavaRewriter (coercion, overload, method/field resolution)
+  → CompilationUnitGenerator (wrap in Evaluator<C,W,O> class)
+  → ClassFilterValidator (optional; rejects forbidden class references)
+  → KieMemoryCompiler (in-memory javac)
+  → ClassManager.define (hidden-class loader)
+  → Evaluator instance
+```
+
+Each stage is deterministic and observable — the intermediate Java
+source is what runs.
+
+## Key design decisions
+
+### Transpile, don't interpret
+The v2 interpreter was the bottleneck for large rule sets. v3 compiles
+once and invokes as Java, trading first-call latency for steady-state
+throughput.
+
+### Three context shapes (MAP / LIST / POJO)
+Each evaluator is generic in `<C, W, O>` (context, with-variable, out).
+The same compiler pipeline emits three slightly different bindings
+depending on how variables are passed in — get-by-key, get-by-index,
+or get-by-getter. See `ContextType`.
+
+### Public `ClassFilter` (issue #413)
+Opt-in compile-time restriction on the classes an expression may
+reference. Defense-in-depth, not a sandbox — source-level filtering
+cannot stop reflection (see `SECURITY.md`). Implemented as a
+post-transpile AST walk in `ClassFilterValidator`, so every class
+reference funnels through one place regardless of which rewriter
+resolved it. Framework scaffolding in the generated class header is
+deliberately skipped to avoid false positives.
+
+### TypeSolver wiring
+The JavaParser symbol solver is built from
+`CombinedTypeSolver(ReflectionTypeSolver, ClassLoaderTypeSolver)` so
+application classes visible via `CompilerParameters.classLoader`
+resolve during transpilation, not just JRE classes.
+
+### Lambda caching
+Compiled evaluators can be cached and persisted by shape via
+`LambdaRegistry` / `LambdaKey`. Same expression text + same variable
+shape = same compiled class, reused across calls.
+
+## Security model
+
+MVEL3 assumes expression authors are trusted. `ClassFilter` reduces
+the blast radius of mistakes; it is not a boundary against adversarial
+input. See `SECURITY.md` for the full stance and reporting process.
+
+## Known limitations
+
+Tracked in `README.md` / `CLAUDE.md`. Notable gaps that affect design:
+- Custom operators (after/before/in/matches) not yet implemented
+- `**`, `<<<` operators not supported / incorrect
+- `HalfBinaryExpr` rewriting not implemented
+
+## Module / package layout
+
+See `CLAUDE.md#Key-Packages` for the current list; this document tracks
+design decisions rather than module inventory.

--- a/src/main/java/org/mvel3/ClassFilter.java
+++ b/src/main/java/org/mvel3/ClassFilter.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel3;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Optional allow/deny policy for class references in an MVEL expression.
+ * Configured via {@link MVELBuilder#classFilter(ClassFilter)}; when not
+ * configured, every class is accepted (default behavior).
+ *
+ * <p><b>Defense-in-depth, not a security boundary.</b> Expression authors are
+ * trusted (see {@code SECURITY.md}). This filter operates on the generated
+ * Java source and cannot stop reflection-based lookups
+ * (e.g. {@code Class.forName}). It reduces the blast radius of mistakes, not
+ * adversarial input.
+ *
+ * <p>Filters compose via {@link #and}, {@link #or}, {@link #negate}. Typical
+ * use: combine an {@link #allowlist} with a {@link #blocklistPackage}, or
+ * start from {@link #SAFE_PRESET} and add further restrictions.
+ */
+@FunctionalInterface
+public interface ClassFilter {
+
+    /** Returns {@code true} if {@code clazz} is permitted, {@code false} to reject. */
+    boolean accept(Class<?> clazz);
+
+    default ClassFilter and(ClassFilter other) {
+        return clazz -> this.accept(clazz) && other.accept(clazz);
+    }
+
+    default ClassFilter or(ClassFilter other) {
+        return clazz -> this.accept(clazz) || other.accept(clazz);
+    }
+
+    default ClassFilter negate() {
+        return clazz -> !this.accept(clazz);
+    }
+
+    /**
+     * Accepts only the listed classes (exact match). Subclasses are NOT
+     * implicitly allowed — use {@link #allowlistWithSubtypes} if you need that.
+     */
+    static ClassFilter allowlist(Class<?>... allowed) {
+        Set<Class<?>> set = new HashSet<>(Arrays.asList(allowed));
+        return set::contains;
+    }
+
+    /**
+     * Accepts any class that equals or is a subtype of one of the listed base classes.
+     */
+    static ClassFilter allowlistWithSubtypes(Class<?>... bases) {
+        Set<Class<?>> set = new HashSet<>(Arrays.asList(bases));
+        return clazz -> {
+            for (Class<?> b : set) {
+                if (b.isAssignableFrom(clazz)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    /**
+     * Rejects the listed classes (exact match). Subclasses are NOT
+     * implicitly rejected — validation runs against a method's
+     * {@code declaringType()}, so a blocklist that included a broad supertype
+     * like {@code Object} or {@code Throwable} would reject harmless inherited
+     * calls. Use {@link #blocklistWithSubtypes} only when you genuinely want
+     * to reject every subtype (e.g. for {@code ClassLoader}).
+     */
+    static ClassFilter blocklist(Class<?>... blocked) {
+        Set<Class<?>> set = new HashSet<>(Arrays.asList(blocked));
+        return clazz -> !set.contains(clazz);
+    }
+
+    /**
+     * Rejects the listed classes and any subtype of them. Use for classes
+     * whose entire hierarchy is dangerous (e.g. {@link ClassLoader}).
+     */
+    static ClassFilter blocklistWithSubtypes(Class<?>... bases) {
+        Set<Class<?>> set = new HashSet<>(Arrays.asList(bases));
+        return clazz -> {
+            for (Class<?> b : set) {
+                if (b.isAssignableFrom(clazz)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+
+    /**
+     * Rejects any class whose fully-qualified name starts with one of the given
+     * prefixes. Useful for package-shaped threat surfaces like
+     * {@code java.lang.reflect.}, {@code sun.}, {@code jdk.internal.}
+     * (include the trailing dot to avoid prefix collisions).
+     */
+    static ClassFilter blocklistPackage(String... prefixes) {
+        String[] copy = prefixes.clone();
+        return clazz -> {
+            String name = clazz.getName();
+            for (String p : copy) {
+                if (name.startsWith(p)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+
+    /** Accepts every class. Useful as an explicit default. */
+    ClassFilter ACCEPT_ALL = clazz -> true;
+
+    /**
+     * A built-in starting point that blocks commonly dangerous classes:
+     * process/thread/classloader hierarchies, {@link System}, {@link Class}
+     * itself, filesystem APIs, and the {@code java.lang.reflect},
+     * {@code java.lang.invoke}, {@code javax.script}, {@code sun.},
+     * {@code jdk.internal.} packages.
+     *
+     * <p>This is a reasonable baseline, not an exhaustive sandbox. Extend it
+     * based on your application's threat model.
+     */
+    ClassFilter SAFE_PRESET =
+            blocklistWithSubtypes(
+                    Runtime.class,
+                    Process.class,
+                    ProcessBuilder.class,
+                    ProcessHandle.class,
+                    ClassLoader.class,
+                    Thread.class)
+            .and(blocklist(
+                    System.class,
+                    Class.class,
+                    java.io.File.class,
+                    java.nio.file.Files.class,
+                    java.nio.file.Paths.class))
+            .and(blocklistPackage(
+                    "java.lang.reflect.",
+                    "java.lang.invoke.",
+                    "javax.script.",
+                    "sun.",
+                    "jdk.internal."));
+}

--- a/src/main/java/org/mvel3/ClassFilterException.java
+++ b/src/main/java/org/mvel3/ClassFilterException.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel3;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Thrown at compile time when the configured {@link ClassFilter} rejects one
+ * or more class references in an MVEL expression. All violations found during
+ * a single compile are batched into a single exception so the author can see
+ * every problem at once rather than fixing them one at a time.
+ */
+public class ClassFilterException extends RuntimeException {
+
+    /**
+     * One blocked class reference, with enough context for an error message.
+     * {@code line} and {@code column} are 1-based; negative values mean the
+     * position was unavailable. {@code reason} is a human-readable phrase
+     * describing why the class was rejected (e.g. "not on the allowlist",
+     * "blocked by ClassFilter").
+     */
+    public record Violation(String className, int line, int column, String reason) {
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            if (line > 0) {
+                sb.append("line ").append(line);
+                if (column > 0) {
+                    sb.append(", col ").append(column);
+                }
+                sb.append(": ");
+            }
+            sb.append("class '").append(className).append("' ").append(reason);
+            return sb.toString();
+        }
+    }
+
+    private final List<Violation> violations;
+
+    public ClassFilterException(List<Violation> violations) {
+        super(buildMessage(violations));
+        this.violations = List.copyOf(violations);
+    }
+
+    public List<Violation> getViolations() {
+        return Collections.unmodifiableList(violations);
+    }
+
+    private static String buildMessage(List<Violation> violations) {
+        if (violations.isEmpty()) {
+            return "ClassFilter rejected the expression (no details)";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(violations.size())
+          .append(" blocked class reference(s) in expression:");
+        for (Violation v : violations) {
+            sb.append("\n  - ").append(v);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/mvel3/ClassFilterValidator.java
+++ b/src/main/java/org/mvel3/ClassFilterValidator.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel3;
+
+import com.github.javaparser.Position;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.ClassExpr;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.InstanceOfExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.MethodReferenceExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.TypeExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
+import com.github.javaparser.resolution.declarations.ResolvedTypeDeclaration;
+import com.github.javaparser.resolution.types.ResolvedType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Post-transpile walker that rejects class references forbidden by a
+ * {@link ClassFilter}. Runs on the fully-transpiled {@link CompilationUnit}
+ * (after {@link org.mvel3.transpiler.MVELTranspiler} has produced the Java
+ * source that javac will compile), so it sees every class reference in one
+ * place regardless of which rewriter resolved it.
+ *
+ * <p>Walks: imports, type nodes ({@link ClassOrInterfaceType}),
+ * {@link ObjectCreationExpr}, {@link ClassExpr} (`.class` literals),
+ * {@link MethodReferenceExpr}, {@link MethodCallExpr} (declaring type),
+ * {@link FieldAccessExpr} (declaring type),
+ * {@link InstanceOfExpr}, {@link TypeExpr}, {@link AnnotationExpr}.
+ *
+ * <p>Violations are batched: every blocked reference found in a single
+ * compile is reported together via one {@link ClassFilterException}.
+ *
+ * <p>Resolution: uses JavaParser's symbol solver first; if that fails, falls
+ * back to {@link Class#forName} with the configured classloader. If both
+ * fail, the node is not a loadable class reference (package path fragment,
+ * typo, etc.) and is skipped — javac will reject genuinely-invalid user code
+ * seconds later, so the filter does not need to double-check.
+ */
+public final class ClassFilterValidator {
+
+    private ClassFilterValidator() {}
+
+    /**
+     * @param unit the transpiled compilation unit about to be handed to javac
+     * @param filter the policy to apply; if {@code null} this method is a no-op
+     * @param classLoader classloader used for last-chance {@link Class#forName}
+     *                    resolution when JavaParser can't resolve a node
+     * @throws ClassFilterException if any class reference is rejected
+     */
+    public static void validate(CompilationUnit unit, ClassFilter filter, ClassLoader classLoader) {
+        if (filter == null) {
+            return;
+        }
+        List<ClassFilterException.Violation> violations = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+
+        // 1. User-supplied imports (the generator only copies the user's
+        //    imports onto the compilation unit, so these are all
+        //    user-authored).
+        for (ImportDeclaration imp : unit.getImports()) {
+            checkImport(imp, filter, classLoader, violations, seen);
+        }
+
+        // 2. User code inside method bodies. We deliberately skip the
+        //    evaluator class's own header (its `implements Evaluator<Map<...>>`
+        //    or `extends` clauses) — that's framework scaffolding, not user
+        //    code, and would cause false positives under a strict allowlist.
+        List<BlockStmt> userCodeBlocks = new ArrayList<>();
+        for (MethodDeclaration method : unit.findAll(MethodDeclaration.class)) {
+            method.getBody().ifPresent(userCodeBlocks::add);
+        }
+        for (BlockStmt body : userCodeBlocks) {
+            walkUserCode(body, filter, classLoader, violations, seen);
+        }
+
+        if (!violations.isEmpty()) {
+            throw new ClassFilterException(violations);
+        }
+    }
+
+    private static void walkUserCode(Node root, ClassFilter filter, ClassLoader classLoader,
+                                      List<ClassFilterException.Violation> violations, Set<String> seen) {
+        root.findAll(ClassOrInterfaceType.class).forEach(t -> {
+            // A ClassOrInterfaceType whose parent is also a ClassOrInterfaceType
+            // is the *scope prefix* of an outer type (e.g. `java.lang` inside
+            // `java.lang.Runtime`). It's a package path fragment, not a real
+            // type reference — the outer type will be checked on its own.
+            if (t.getParentNode().filter(p -> p instanceof ClassOrInterfaceType).isPresent()) {
+                return;
+            }
+            checkClassName(resolveTypeName(t), t, filter, classLoader, violations, seen);
+        });
+
+        root.findAll(ObjectCreationExpr.class).forEach(oc ->
+                checkClassName(resolveTypeName(oc.getType()), oc, filter, classLoader, violations, seen));
+
+        root.findAll(ClassExpr.class).forEach(ce ->
+                checkClassName(resolveTypeNameFromType(ce.getType()), ce, filter, classLoader, violations, seen));
+
+        root.findAll(InstanceOfExpr.class).forEach(ie ->
+                checkClassName(resolveTypeNameFromType(ie.getType()), ie, filter, classLoader, violations, seen));
+
+        root.findAll(TypeExpr.class).forEach(te ->
+                checkClassName(resolveTypeNameFromType(te.getType()), te, filter, classLoader, violations, seen));
+
+        root.findAll(AnnotationExpr.class).forEach(ae ->
+                checkClassName(resolveAnnotationName(ae), ae, filter, classLoader, violations, seen));
+
+        root.findAll(MethodReferenceExpr.class).forEach(mr ->
+                checkClassName(resolveMethodReferenceScope(mr), mr, filter, classLoader, violations, seen));
+
+        root.findAll(MethodCallExpr.class).forEach(mc ->
+                checkClassName(resolveMethodDeclaringType(mc), mc, filter, classLoader, violations, seen));
+
+        root.findAll(FieldAccessExpr.class).forEach(fa ->
+                checkClassName(resolveFieldDeclaringType(fa), fa, filter, classLoader, violations, seen));
+    }
+
+    // ----- resolution helpers ------------------------------------------------
+
+    private static String resolveTypeName(ClassOrInterfaceType t) {
+        try {
+            ResolvedType r = t.resolve();
+            if (r.isReferenceType()) {
+                return r.asReferenceType().getQualifiedName();
+            }
+        } catch (Throwable ignore) {
+            // fall through to fallback
+        }
+        return t.getNameWithScope();
+    }
+
+    private static String resolveTypeNameFromType(com.github.javaparser.ast.type.Type t) {
+        try {
+            ResolvedType r = t.resolve();
+            return qualifiedNameOf(r);
+        } catch (Throwable ignore) {
+            return t.asString();
+        }
+    }
+
+    private static String qualifiedNameOf(ResolvedType r) {
+        if (r == null) return null;
+        if (r.isPrimitive() || r.isVoid() || r.isNull() || r.isTypeVariable() || r.isWildcard()) {
+            return null;
+        }
+        if (r.isArray()) {
+            return qualifiedNameOf(r.asArrayType().getComponentType());
+        }
+        if (r.isReferenceType()) {
+            return r.asReferenceType().getQualifiedName();
+        }
+        return null;
+    }
+
+    private static String resolveAnnotationName(AnnotationExpr ae) {
+        try {
+            ResolvedTypeDeclaration d = (ResolvedTypeDeclaration) ae.resolve();
+            if (d instanceof ResolvedReferenceTypeDeclaration r) {
+                return r.getQualifiedName();
+            }
+        } catch (Throwable ignore) {
+        }
+        return ae.getNameAsString();
+    }
+
+    private static String resolveMethodReferenceScope(MethodReferenceExpr mr) {
+        try {
+            ResolvedType r = mr.getScope().calculateResolvedType();
+            return qualifiedNameOf(r);
+        } catch (Throwable ignore) {
+            return mr.getScope().toString();
+        }
+    }
+
+    private static String resolveMethodDeclaringType(MethodCallExpr mc) {
+        try {
+            ResolvedMethodDeclaration m = mc.resolve();
+            return m.declaringType().getQualifiedName();
+        } catch (Throwable ignore) {
+            return null;
+        }
+    }
+
+    private static String resolveFieldDeclaringType(FieldAccessExpr fa) {
+        try {
+            var resolved = fa.resolve();
+            if (resolved.isField()) {
+                return resolved.asField().declaringType().getQualifiedName();
+            }
+        } catch (Throwable ignore) {
+        }
+        return null;
+    }
+
+    // ----- filter check ------------------------------------------------------
+
+    private static void checkImport(ImportDeclaration imp, ClassFilter filter, ClassLoader cl,
+                                     List<ClassFilterException.Violation> violations, Set<String> seen) {
+        if (imp.isAsterisk()) {
+            // Star imports have no single class to check here. Their uses are
+            // caught via type / method-call / field-access walks below.
+            return;
+        }
+        String name = imp.getNameAsString();
+        // Static imports reference a member; the declaring class is the part
+        // before the last dot.
+        if (imp.isStatic()) {
+            int dot = name.lastIndexOf('.');
+            if (dot > 0) {
+                name = name.substring(0, dot);
+            }
+        }
+        checkClassName(name, imp, filter, cl, violations, seen);
+    }
+
+    private static void checkClassName(String name, Node node, ClassFilter filter, ClassLoader cl,
+                                        List<ClassFilterException.Violation> violations, Set<String> seen) {
+        if (name == null || name.isEmpty()) {
+            return;
+        }
+        // Strip array brackets, if any leaked through.
+        while (name.endsWith("[]")) {
+            name = name.substring(0, name.length() - 2);
+        }
+        // Skip primitive type names (they're never classes under a filter).
+        switch (name) {
+            case "boolean": case "byte": case "short": case "int":
+            case "long": case "float": case "double": case "char": case "void":
+                return;
+        }
+        String dedupKey = name + "@" + positionKey(node);
+        if (!seen.add(dedupKey)) {
+            return;
+        }
+        Class<?> clazz = loadClass(name, cl);
+        if (clazz == null) {
+            // If neither JavaParser nor the user classLoader can load it, this
+            // isn't a real class reference (package path fragment, typo, etc.).
+            // javac will reject genuinely-invalid user references a moment later,
+            // so we don't need to false-positive here.
+            return;
+        }
+        if (!filter.accept(clazz)) {
+            violations.add(violation(clazz.getName(), node, "is not permitted by the configured ClassFilter"));
+        }
+    }
+
+    private static Class<?> loadClass(String name, ClassLoader cl) {
+        ClassLoader loader = cl != null ? cl : Thread.currentThread().getContextClassLoader();
+        if (loader == null) {
+            loader = ClassFilterValidator.class.getClassLoader();
+        }
+        try {
+            return Class.forName(name, false, loader);
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            // Try treating the last segment as an inner class.
+            int lastDot = name.lastIndexOf('.');
+            while (lastDot > 0) {
+                name = name.substring(0, lastDot) + "$" + name.substring(lastDot + 1);
+                try {
+                    return Class.forName(name, false, loader);
+                } catch (ClassNotFoundException | NoClassDefFoundError ignore) {
+                }
+                lastDot = name.lastIndexOf('.', lastDot - 1);
+            }
+            return null;
+        }
+    }
+
+    private static ClassFilterException.Violation violation(String name, Node node, String reason) {
+        Position p = node.getBegin().orElse(null);
+        int line = p == null ? -1 : p.line;
+        int col = p == null ? -1 : p.column;
+        return new ClassFilterException.Violation(name, line, col, reason);
+    }
+
+    private static String positionKey(Node node) {
+        return node.getBegin().map(p -> p.line + ":" + p.column).orElse("?");
+    }
+}

--- a/src/main/java/org/mvel3/CompilerParameters.java
+++ b/src/main/java/org/mvel3/CompilerParameters.java
@@ -2,7 +2,6 @@ package org.mvel3;
 
 import org.mvel3.transpiler.context.Declaration;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +22,8 @@ public record CompilerParameters<T, K, R>(ContextType contextType,
                                           String expression,
                                           String generatedClassName,
                                           String generatedMethodName,
-                                          String generatedSuperName) {
+                                          String generatedSuperName,
+                                          ClassFilter classFilter) {
 
     public Map<String, Declaration> allVars() {
         if (variableDeclarations.isEmpty()) {

--- a/src/main/java/org/mvel3/MVELBuilder.java
+++ b/src/main/java/org/mvel3/MVELBuilder.java
@@ -193,6 +193,8 @@ public class MVELBuilder<C, W, O> {
 
     private String generatedSuperName;
 
+    private ClassFilter classFilter;
+
     public static <C, W, O> MVELBuilder<C, W, O> create() {
         MVELBuilder builder = new MVELBuilder<>();
         builder.outType = Type.type(Void.class); // default no return
@@ -209,6 +211,7 @@ public class MVELBuilder<C, W, O> {
         builder.outType         = template.outType;
         builder.generatedClassName = template.generatedClassName;
         builder.generatedMethodName = template.generatedMethodName;
+        builder.classFilter = template.classFilter;
 
         return builder;
     }
@@ -326,6 +329,17 @@ public class MVELBuilder<C, W, O> {
         return this;
     }
 
+    /**
+     * Restricts which classes may be referenced by the compiled expression.
+     * When {@code null} (the default), no class filtering is applied. See
+     * {@link ClassFilter} for factory methods and the {@code SAFE_PRESET}
+     * baseline.
+     */
+    public MVELBuilder<C, W, O> classFilter(ClassFilter classFilter) {
+        this.classFilter = classFilter;
+        return this;
+    }
+
     public Evaluator<C, W, O>  compile() {
         return compile(build());
     }
@@ -356,7 +370,7 @@ public class MVELBuilder<C, W, O> {
 
         CompilerParameters<C, W, O> info = new CompilerParameters<>(contextType, classLoader, classManager, imports, staticImports, outType,
                                                                     contextDeclaration, variableDeclarations, withDeclaration, contentType, content,
-                                                                    generatedClassName, generatedMethodName, generatedSuperName);
+                                                                    generatedClassName, generatedMethodName, generatedSuperName, classFilter);
 
         return info;
     }

--- a/src/main/java/org/mvel3/MVELCompiler.java
+++ b/src/main/java/org/mvel3/MVELCompiler.java
@@ -185,7 +185,11 @@ public class MVELCompiler {
     private <T, K, R> CompilationUnit compileNoLoad(CompilerParameters<T, K, R> info) {
         TranspiledResult input = transpile(info);
 
-        return new CompilationUnitGenerator(input.getTranspilerContext().getParser()).createCompilationUnit(input, info);
+        CompilationUnit unit = new CompilationUnitGenerator(input.getTranspilerContext().getParser()).createCompilationUnit(input, info);
+
+        ClassFilterValidator.validate(unit, info.classFilter(), info.classLoader());
+
+        return unit;
     }
 
     private <C, W, O> Evaluator<C, W, O> compileEvaluator(CompilationUnit unit, CompilerParameters<C, W, O> info) {

--- a/src/main/java/org/mvel3/transpiler/MVELTranspiler.java
+++ b/src/main/java/org/mvel3/transpiler/MVELTranspiler.java
@@ -34,6 +34,8 @@ import com.github.javaparser.ast.stmt.ReturnStmt;
 import com.github.javaparser.ast.stmt.Statement;
 import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ClassLoaderTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import org.mvel3.ContentType;
 import org.mvel3.CompilerParameters;
@@ -57,7 +59,7 @@ public class MVELTranspiler {
 
     public static <T, K, R>  TranspiledResult transpile(CompilerParameters<T, K, R> evalInfo, EvalPre evalPre) {
 
-        TypeSolver typeSolver = new ReflectionTypeSolver(false);
+        TypeSolver typeSolver = buildTypeSolver(evalInfo.classLoader());
         JavaSymbolSolver solver = new JavaSymbolSolver(typeSolver);
 
         ParserConfiguration conf = new ParserConfiguration();
@@ -73,6 +75,19 @@ public class MVELTranspiler {
         TranspiledResult transpiledResult =  mvelTranspiler.transpileContent(evalInfo, evalPre);
 
         return transpiledResult;
+    }
+
+    /**
+     * Builds a TypeSolver that can see both the JRE classes (via reflection)
+     * and application classes visible through the caller-supplied classLoader.
+     * Falls back to the default ReflectionTypeSolver when no classLoader is
+     * configured on the CompilerParameters.
+     */
+    static TypeSolver buildTypeSolver(ClassLoader classLoader) {
+        if (classLoader == null) {
+            return new ReflectionTypeSolver(false);
+        }
+        return new CombinedTypeSolver(new ReflectionTypeSolver(false), new ClassLoaderTypeSolver(classLoader));
     }
 
     public static <T> T handleParserResult(ParseResult<T> result) {

--- a/src/main/java/org/mvel3/util/TypeResolver.java
+++ b/src/main/java/org/mvel3/util/TypeResolver.java
@@ -47,8 +47,13 @@ public interface TypeResolver {
 
     ClassLoader getClassLoader();
 
-    interface ClassFilter {
-        boolean accept( Class<?> clazz );
+    /**
+     * @deprecated Use {@link org.mvel3.ClassFilter} instead. This nested
+     * interface is kept only so existing internal callers still compile; it
+     * extends the public interface without adding any members.
+     */
+    @Deprecated
+    interface ClassFilter extends org.mvel3.ClassFilter {
     }
 
     AcceptAllClassFilter ACCEPT_ALL_CLASS_FILTER = new AcceptAllClassFilter();

--- a/src/test/java/org/mvel3/ClassFilterTest.java
+++ b/src/test/java/org/mvel3/ClassFilterTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mvel3;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mvel3.parser.MvelParser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class ClassFilterTest {
+
+    @BeforeAll
+    static void enableAntlrParser() {
+        MvelParser.Factory.USE_ANTLR = true;
+    }
+
+    private Evaluator<Map<String, Object>, Void, Object> compile(String expression, ClassFilter filter) {
+        return compile(expression, filter, Set.of());
+    }
+
+    private Evaluator<Map<String, Object>, Void, Object> compile(String expression, ClassFilter filter, Set<String> imports) {
+        MVELBuilder<Map<String, Object>, Void, Object> b = MVEL.<Object>map()
+                .<Object>out(Object.class)
+                .expression(expression)
+                .classManager(new ClassManager())
+                .classLoader(ClassLoader.getSystemClassLoader())
+                .imports(imports);
+        if (filter != null) {
+            b.classFilter(filter);
+        }
+        return b.compile();
+    }
+
+    private Evaluator<Map<String, Object>, Void, Object> compileBlock(String block, ClassFilter filter, Set<String> imports) {
+        MVELBuilder<Map<String, Object>, Void, Object> b = MVEL.<Object>map()
+                .<Object>out(Object.class)
+                .block(block)
+                .classManager(new ClassManager())
+                .classLoader(ClassLoader.getSystemClassLoader())
+                .imports(imports);
+        if (filter != null) {
+            b.classFilter(filter);
+        }
+        return b.compile();
+    }
+
+    // 1. no filter configured → no restriction (regression check)
+    @Test
+    void noFilter_allowsEverything() {
+        assertThatNoException().isThrownBy(() ->
+                compile("new java.util.ArrayList()", null));
+    }
+
+    // 2. blocklist rejects Runtime
+    @Test
+    void blocklist_rejectsRuntime() {
+        ClassFilter filter = ClassFilter.blocklist(Runtime.class);
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("java.lang.Runtime.getRuntime()", filter))
+                .satisfies(ex -> {
+                    assertThat(ex.getMessage()).contains("java.lang.Runtime");
+                    assertThat(ex.getViolations()).isNotEmpty();
+                });
+    }
+
+    // 3. blocklistWithSubtypes rejects subtypes
+    @Test
+    void blocklistWithSubtypes_rejectsSubtype() {
+        // URLClassLoader extends ClassLoader -> blocked
+        ClassFilter filter = ClassFilter.blocklistWithSubtypes(ClassLoader.class);
+        Set<String> imports = new HashSet<>();
+        imports.add("java.net.URLClassLoader");
+        imports.add("java.net.URL");
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("new URLClassLoader(new URL[0])", filter, imports));
+    }
+
+    // 4. allowlist — allowed class works, unlisted class rejected
+    @Test
+    void allowlist_allowsListedAndRejectsOthers() {
+        ClassFilter filter = ClassFilter.allowlist(ArrayList.class, String.class, Object.class);
+
+        assertThatNoException().isThrownBy(() ->
+                compile("new ArrayList()", filter, Set.of("java.util.ArrayList")));
+
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("new HashMap()", filter, Set.of("java.util.HashMap")));
+    }
+
+    // 5. SAFE_PRESET — normal code works, dangerous code blocked
+    @Test
+    void safePreset_blocksRuntimeAllowsCollections() {
+        Set<String> imports = Set.of("java.util.ArrayList");
+        assertThatNoException().isThrownBy(() ->
+                compile("new ArrayList()", ClassFilter.SAFE_PRESET, imports));
+
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("java.lang.Runtime.getRuntime()", ClassFilter.SAFE_PRESET));
+    }
+
+    // 6. Import-level rejection. Note: JavaParser silently drops java.lang
+    // imports because java.lang is auto-imported, so we test with java.io.File.
+    @Test
+    void importOfBlockedClass_rejected() {
+        ClassFilter filter = ClassFilter.blocklist(java.io.File.class);
+        Set<String> imports = Set.of("java.io.File");
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("1", filter, imports))
+                .satisfies(ex -> assertThat(ex.getMessage()).contains("java.io.File"));
+    }
+
+    // 7. .class literal rejection
+    @Test
+    void classLiteral_rejected() {
+        ClassFilter filter = ClassFilter.blocklist(Runtime.class);
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("java.lang.Runtime.class", filter));
+    }
+
+    // 8. array-of-blocked-type rejection
+    @Test
+    void arrayOfBlockedClass_rejected() {
+        ClassFilter filter = ClassFilter.blocklist(Runtime.class);
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("new java.lang.Runtime[0]", filter));
+    }
+
+    // 9. instanceof rejection
+    @Test
+    void instanceofBlockedClass_rejected() {
+        ClassFilter filter = ClassFilter.blocklistWithSubtypes(ClassLoader.class);
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("x", "hello");
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("x instanceof java.lang.ClassLoader", filter));
+    }
+
+    // 10. Batched error output — multiple violations in one exception
+    @Test
+    void batchedErrors_reportedTogether() {
+        ClassFilter filter = ClassFilter.blocklist(Runtime.class, java.io.File.class);
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compileBlock(
+                        "java.lang.Runtime r = null; java.io.File f = null; return r;",
+                        filter, Set.of()))
+                .satisfies(ex -> {
+                    assertThat(ex.getViolations()).hasSizeGreaterThanOrEqualTo(2);
+                    String msg = ex.getMessage();
+                    assertThat(msg).contains("Runtime");
+                    assertThat(msg).contains("File");
+                });
+    }
+
+    // 11. Blocklist exact-match does NOT reject subtypes unintentionally
+    @Test
+    void blocklistExactMatch_doesNotRejectUnrelated() {
+        // blocklist Runtime but don't touch Object/ArrayList/etc. Every
+        // method call's declaringType() chain passes through Object, so a
+        // broken implementation would flag this.
+        ClassFilter filter = ClassFilter.blocklist(Runtime.class);
+        assertThatNoException().isThrownBy(() ->
+                compile("new java.util.ArrayList().toString()", filter));
+    }
+
+    // 12. Exact blocklist does NOT reject Runtime's supertype Object
+    @Test
+    void blocklistExactMatch_doesNotRejectSupertype() {
+        ClassFilter filter = ClassFilter.blocklist(ArrayList.class);
+        // HashMap uses Object in its method chain; must still compile
+        assertThatNoException().isThrownBy(() ->
+                compile("new java.util.HashMap().toString()", filter));
+    }
+
+    // 13. blocklistPackage rejects members of the package
+    @Test
+    void blocklistPackage_rejectsPackageMember() {
+        ClassFilter filter = ClassFilter.blocklistPackage("java.lang.reflect.");
+        Set<String> imports = Set.of("java.lang.reflect.Method");
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("1", filter, imports));
+    }
+
+    // 14. Composed filter: allowlist AND blocklist must BOTH pass
+    @Test
+    void composedFilter_allowlistAndBlocklist() {
+        ClassFilter filter = ClassFilter.allowlistWithSubtypes(Object.class)
+                .and(ClassFilter.blocklist(Runtime.class));
+        // ArrayList -> accepted by allowlist, not in blocklist -> OK
+        Set<String> imports = Set.of("java.util.ArrayList");
+        assertThatNoException().isThrownBy(() ->
+                compile("new ArrayList()", filter, imports));
+        // Runtime -> accepted by allowlist but in blocklist -> rejected
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("java.lang.Runtime.getRuntime()", filter));
+    }
+
+    // 15. Violations carry source position
+    @Test
+    void violation_hasSourcePosition() {
+        ClassFilter filter = ClassFilter.blocklist(Runtime.class);
+        assertThatExceptionOfType(ClassFilterException.class)
+                .isThrownBy(() -> compile("java.lang.Runtime.getRuntime()", filter))
+                .satisfies(ex -> {
+                    List<ClassFilterException.Violation> vs = ex.getViolations();
+                    assertThat(vs).isNotEmpty();
+                    assertThat(vs.get(0).line()).isPositive();
+                });
+    }
+
+    // 16. Normal evaluator execution works end-to-end with filter configured
+    @Test
+    void endToEnd_evalRunsWithFilter() {
+        Evaluator<Map<String, Object>, Void, Object> eval = compile(
+                "1 + 2", ClassFilter.SAFE_PRESET);
+        assertThat(eval.eval(new HashMap<>())).isEqualTo(3);
+    }
+}

--- a/src/test/java/org/mvel3/CompilationUnitCompilerTest.java
+++ b/src/test/java/org/mvel3/CompilationUnitCompilerTest.java
@@ -185,6 +185,7 @@ class CompilationUnitCompilerTest {
                 "",
                 "Generated__",
                 "eval",
+                null,
                 null
         );
 

--- a/src/test/java/org/mvel3/CompilationUnitTranspilerTest.java
+++ b/src/test/java/org/mvel3/CompilationUnitTranspilerTest.java
@@ -147,6 +147,7 @@ class CompilationUnitTranspilerTest {
                 "",
                 "Generated__",
                 "eval",
+                null,
                 null
         );
 


### PR DESCRIPTION
Closes https://github.com/mvel/mvel/issues/413

----
ClassFilter lets consuming applications restrict which classes may be referenced by an MVEL expression. It is opt-in (no filter = unchanged behavior) and operates at compile time — zero runtime overhead once the evaluator is compiled.

Public API:
  - org.mvel3.ClassFilter functional interface
  - factories: allowlist, allowlistWithSubtypes, blocklist, blocklistWithSubtypes, blocklistPackage; combinators and/or/negate
  - ClassFilter.SAFE_PRESET baseline (blocks Runtime/Process/Thread/ ClassLoader hierarchies, System, Class, filesystem APIs, and the java.lang.reflect, java.lang.invoke, javax.script, sun., jdk.internal. packages)
  - MVELBuilder#classFilter(ClassFilter) wires it through CompilerParameters
  - ClassFilterException batches all violations with source positions

Implementation:
  - ClassFilterValidator walks the final CompilationUnit after transpile, checking imports and method-body references (ClassOrInterfaceType, ObjectCreationExpr, ClassExpr, MethodCallExpr declaring type, MethodReferenceExpr, FieldAccessExpr, InstanceOfExpr, TypeExpr, AnnotationExpr)
  - Framework scaffolding in the generated class header is deliberately skipped to avoid false positives
  - MVELTranspiler now wires CompilerParameters.classLoader into the JavaParser TypeSolver (CombinedTypeSolver with ClassLoaderTypeSolver) so application classes resolve during validation
  - TypeResolver.ClassFilter is deprecated; it now extends the public org.mvel3.ClassFilter

Defense-in-depth, not a security boundary — reflection (Class.forName) cannot be stopped at source level. See SECURITY.md.