### PR TITLE
[mvel-423] Surface read-properties on Evaluator for property-reactive consumers

### DIFF
--- a/src/main/java/org/mvel3/Evaluator.java
+++ b/src/main/java/org/mvel3/Evaluator.java
@@ -77,4 +77,18 @@ public interface Evaluator<C, W, O> {
     default O evalWith(W w) {
         throw new RuntimeException("Not Implemented");
     }
+
+    /**
+     * Returns the names of properties that the compiled expression reads from
+     * its context. Populated only for POJO-context evaluators; empty otherwise.
+     * <p>
+     * The returned names are <em>candidates</em> derived from AST analysis — bare
+     * identifiers and no-arg getter calls. Consumers are expected to filter
+     * against the actual settable-property set of the context type.
+     *
+     * @return property names referenced by the expression, or an empty array
+     */
+    default String[] getReadProperties() {
+        return new String[0];
+    }
 }

--- a/src/main/java/org/mvel3/transpiler/MVELTranspiler.java
+++ b/src/main/java/org/mvel3/transpiler/MVELTranspiler.java
@@ -177,6 +177,12 @@ public class MVELTranspiler {
             rewriter.rewriteChildren(method.getBody().get());
         }
 
+        // Emit getReadProperties() override AFTER the eval method so downstream
+        // logic that calls findFirst(MethodDeclaration.class) still finds the
+        // eval method. Consumers (e.g. DRLX alpha-mask construction) filter the
+        // returned names against the actual settable-property set.
+        emitGetReadPropertiesOverride(classDeclaration, analyser.getReadProperties());
+
 //        // Inject the "return" if one is needed and it's missing and it's a statement expression.
 //        // This will not check branchs of an if statement or for loop, those need explicit returns
 //        Statement stmt = method.getBody().get().getStatements().getLast().get();
@@ -196,5 +202,24 @@ public class MVELTranspiler {
         logger.debug("Generated compilation unit:\n{}", PrintUtil.printNode(unit));
 
         return new TranspiledBlockResult(unit, classDeclaration, method, context);
+    }
+
+    private static void emitGetReadPropertiesOverride(
+            com.github.javaparser.ast.body.ClassOrInterfaceDeclaration classDeclaration,
+            java.util.Set<String> readProperties) {
+        com.github.javaparser.ast.body.MethodDeclaration m = classDeclaration.addMethod("getReadProperties");
+        m.setPublic(true);
+        m.setType("String[]");
+        m.addAnnotation("Override");
+        StringBuilder body = new StringBuilder("return new String[]{");
+        boolean first = true;
+        for (String p : readProperties) {
+            if (!first) body.append(", ");
+            body.append('"').append(p.replace("\"", "\\\"")).append('"');
+            first = false;
+        }
+        body.append("};");
+        m.setBody(new com.github.javaparser.ast.stmt.BlockStmt()
+                .addStatement(body.toString()));
     }
 }

--- a/src/main/java/org/mvel3/transpiler/VariableAnalyser.java
+++ b/src/main/java/org/mvel3/transpiler/VariableAnalyser.java
@@ -1,9 +1,11 @@
 package org.mvel3.transpiler;
+import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import org.mvel3.parser.ast.expr.DrlNameExpr;
 import org.mvel3.parser.ast.visitor.DrlVoidVisitorAdapter;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class VariableAnalyser extends DrlVoidVisitorAdapter<Void> {
@@ -13,22 +15,41 @@ public class VariableAnalyser extends DrlVoidVisitorAdapter<Void> {
 
     private Set<String> found = new HashSet<>();
 
+    // All identifier reads in the expression (NameExpr names + decoded no-arg getter calls).
+    // Iteration order preserved so generated arrays are deterministic across builds.
+    // Consumers filter against the actual settable-property set of the context type.
+    private Set<String> readProperties = new LinkedHashSet<>();
+
     public VariableAnalyser(Set<String> available) {
         this.available = available;
     }
 
     public void visit(NameExpr n, Void arg) {
-        if (available.contains(n.getNameAsString())) {
-            used.add(n.getNameAsString());
+        String name = n.getNameAsString();
+        if (available.contains(name)) {
+            used.add(name);
         }
+        readProperties.add(name);
     }
 
     public void visit(DrlNameExpr n, Void arg) {
-        if (available.contains(n.getNameAsString())) {
-            used.add(n.getNameAsString());
+        String name = n.getNameAsString();
+        if (available.contains(name)) {
+            used.add(name);
         } else {
-            found.add(n.getNameAsString());
+            found.add(name);
         }
+        readProperties.add(name);
+    }
+
+    public void visit(MethodCallExpr n, Void arg) {
+        if (n.getScope().isEmpty() && n.getArguments().isEmpty()) {
+            String prop = getter2property(n.getNameAsString());
+            if (prop != null) {
+                readProperties.add(prop);
+            }
+        }
+        super.visit(n, arg);
     }
 
     public Set<String> getUsed() {
@@ -37,5 +58,23 @@ public class VariableAnalyser extends DrlVoidVisitorAdapter<Void> {
 
     public Set<String> getFound() {
         return found;
+    }
+
+    public Set<String> getReadProperties() {
+        return readProperties;
+    }
+
+    /**
+     * JavaBeans getter name → property name. Returns null if the name does not
+     * follow the {@code getXxx} / {@code isXxx} convention.
+     */
+    static String getter2property(String methodName) {
+        if (methodName.startsWith("get") && methodName.length() > 3) {
+            return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
+        }
+        if (methodName.startsWith("is") && methodName.length() > 2) {
+            return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
+        }
+        return null;
     }
 }

--- a/src/main/java/org/mvel3/transpiler/VariableAnalyser.java
+++ b/src/main/java/org/mvel3/transpiler/VariableAnalyser.java
@@ -1,5 +1,4 @@
 package org.mvel3.transpiler;
-import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import org.mvel3.parser.ast.expr.DrlNameExpr;
 import org.mvel3.parser.ast.visitor.DrlVoidVisitorAdapter;
@@ -15,7 +14,7 @@ public class VariableAnalyser extends DrlVoidVisitorAdapter<Void> {
 
     private Set<String> found = new HashSet<>();
 
-    // All identifier reads in the expression (NameExpr names + decoded no-arg getter calls).
+    // Names of identifiers read by the expression (every NameExpr / DrlNameExpr).
     // Iteration order preserved so generated arrays are deterministic across builds.
     // Consumers filter against the actual settable-property set of the context type.
     private Set<String> readProperties = new LinkedHashSet<>();
@@ -42,16 +41,6 @@ public class VariableAnalyser extends DrlVoidVisitorAdapter<Void> {
         readProperties.add(name);
     }
 
-    public void visit(MethodCallExpr n, Void arg) {
-        if (n.getScope().isEmpty() && n.getArguments().isEmpty()) {
-            String prop = getter2property(n.getNameAsString());
-            if (prop != null) {
-                readProperties.add(prop);
-            }
-        }
-        super.visit(n, arg);
-    }
-
     public Set<String> getUsed() {
         return used;
     }
@@ -62,19 +51,5 @@ public class VariableAnalyser extends DrlVoidVisitorAdapter<Void> {
 
     public Set<String> getReadProperties() {
         return readProperties;
-    }
-
-    /**
-     * JavaBeans getter name → property name. Returns null if the name does not
-     * follow the {@code getXxx} / {@code isXxx} convention.
-     */
-    static String getter2property(String methodName) {
-        if (methodName.startsWith("get") && methodName.length() > 3) {
-            return Character.toLowerCase(methodName.charAt(3)) + methodName.substring(4);
-        }
-        if (methodName.startsWith("is") && methodName.length() > 2) {
-            return Character.toLowerCase(methodName.charAt(2)) + methodName.substring(3);
-        }
-        return null;
     }
 }

--- a/src/test/java/org/mvel3/transpiler/ReadPropertiesTest.java
+++ b/src/test/java/org/mvel3/transpiler/ReadPropertiesTest.java
@@ -1,0 +1,36 @@
+package org.mvel3.transpiler;
+
+import org.junit.jupiter.api.Test;
+import org.mvel3.ClassManager;
+import org.mvel3.CompilerParameters;
+import org.mvel3.Evaluator;
+import org.mvel3.MVEL;
+import org.mvel3.transpiler.context.Declaration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReadPropertiesTest {
+
+    /**
+     * Mirrors DRLX's compilation pattern: every JavaBeans property of the
+     * pattern type is registered as an explicit Declaration so that bare
+     * identifiers in the expression resolve against them.
+     */
+    private Evaluator<Object, Void, Boolean> compile(String expression) {
+        CompilerParameters<Object, Void, Boolean> info = MVEL.pojo(ReadPropsFixture.class,
+                        Declaration.of("salary", int.class),
+                        Declaration.of("basePay", int.class),
+                        Declaration.of("active", boolean.class))
+                .<Boolean>out(Boolean.class)
+                .expression(expression)
+                .classManager(new ClassManager())
+                .build();
+        return new MVEL().compilePojoEvaluator(info);
+    }
+
+    @Test
+    void bareNameExpr_collectsProperty() {
+        Evaluator<Object, Void, Boolean> ev = compile("salary > 0");
+        assertThat(ev.getReadProperties()).containsExactlyInAnyOrder("salary");
+    }
+}

--- a/src/test/java/org/mvel3/transpiler/ReadPropertiesTest.java
+++ b/src/test/java/org/mvel3/transpiler/ReadPropertiesTest.java
@@ -33,4 +33,16 @@ class ReadPropertiesTest {
         Evaluator<Object, Void, Boolean> ev = compile("salary > 0");
         assertThat(ev.getReadProperties()).containsExactlyInAnyOrder("salary");
     }
+
+    @Test
+    void multipleProperties_collectsAll() {
+        Evaluator<Object, Void, Boolean> ev = compile("salary > 0 && basePay == 1000");
+        assertThat(ev.getReadProperties()).containsExactlyInAnyOrder("salary", "basePay");
+    }
+
+    @Test
+    void noProperties_returnsEmpty() {
+        Evaluator<Object, Void, Boolean> ev = compile("1 == 1");
+        assertThat(ev.getReadProperties()).isEmpty();
+    }
 }

--- a/src/test/java/org/mvel3/transpiler/ReadPropsFixture.java
+++ b/src/test/java/org/mvel3/transpiler/ReadPropsFixture.java
@@ -1,0 +1,16 @@
+package org.mvel3.transpiler;
+
+public class ReadPropsFixture {
+    private int salary;
+    private int basePay;
+    private boolean active;
+
+    public int getSalary() { return salary; }
+    public void setSalary(int salary) { this.salary = salary; }
+
+    public int getBasePay() { return basePay; }
+    public void setBasePay(int basePay) { this.basePay = basePay; }
+
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
+}


### PR DESCRIPTION
Closes https://github.com/mvel/mvel/issues/423

This will generate code like:
```
public class GeneratorEvaluator__ implements org.mvel3.Evaluator<org.mvel3.transpiler.ReadPropsFixture, java.lang.Void, java.lang.Boolean> {

    public java.lang.Boolean eval(org.mvel3.transpiler.ReadPropsFixture __context) {
        int salary = __context.getSalary();
        return salary > 0;
    }

    @Override()
    public String[] getReadProperties() {
        return new String[] { "salary" };
    }
}
```
So the application can call `getReadProperties` for its purpose.