### PR TITLE
[mvel-425] MVEL.map: bean-getter rewrite skipped inside !(...) — fix …

### DIFF
--- a/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
+++ b/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
@@ -451,25 +451,28 @@ public class MVELToJavaRewriter {
                 // JavaParser's extension to detect BigDecimal and BigNumber does not pass  the negative prefix on the number.
                 // This detects this and adds it back in.
                 UnaryExpr unaryExpr = (UnaryExpr) node;
-                if (unaryExpr.getOperator() == UnaryExpr.Operator.MINUS ||
-                    unaryExpr.getOperator() == UnaryExpr.Operator.PLUS) {
-                    if (unaryExpr.getExpression() instanceof BigDecimalLiteralExpr ||
-                        unaryExpr.getExpression() instanceof BigIntegerLiteralExpr) {
-                        LiteralStringValueExpr lit = (LiteralStringValueExpr) unaryExpr.getExpression();
-                        lit.setValue(unaryExpr.getOperator().asString() + lit.getValue().substring(0, lit.getValue().length()));
-                        rewriteNode(unaryExpr.getExpression());
-                        unaryExpr.replace(unaryExpr.getExpression());
-                    }
-                } else if (unaryExpr.getOperator() == UnaryExpr.Operator.BITWISE_COMPLEMENT) {
-                    if (unaryExpr.getExpression() instanceof BigIntegerLiteralExpr) {
-                        rewriteNode(unaryExpr.getExpression());
-                        Expression     expr = unaryExpr.getExpression();
-                        MethodCallExpr not  = new MethodCallExpr(expr, "not");
-                        Node           p    = unaryExpr.getParentNode().get();
-                        unaryExpr.replace(not);
-                    } else if (unaryExpr.getExpression() instanceof BigDecimalLiteralExpr) {
-                        throw new UnsupportedOperationException("BigDecimals cannot use bitwise compliment operators");
-                    }
+                if ((unaryExpr.getOperator() == UnaryExpr.Operator.MINUS ||
+                     unaryExpr.getOperator() == UnaryExpr.Operator.PLUS) &&
+                    (unaryExpr.getExpression() instanceof BigDecimalLiteralExpr ||
+                     unaryExpr.getExpression() instanceof BigIntegerLiteralExpr)) {
+                    LiteralStringValueExpr lit = (LiteralStringValueExpr) unaryExpr.getExpression();
+                    lit.setValue(unaryExpr.getOperator().asString() + lit.getValue().substring(0, lit.getValue().length()));
+                    rewriteNode(unaryExpr.getExpression());
+                    unaryExpr.replace(unaryExpr.getExpression());
+                } else if (unaryExpr.getOperator() == UnaryExpr.Operator.BITWISE_COMPLEMENT &&
+                           unaryExpr.getExpression() instanceof BigIntegerLiteralExpr) {
+                    rewriteNode(unaryExpr.getExpression());
+                    Expression     expr = unaryExpr.getExpression();
+                    MethodCallExpr not  = new MethodCallExpr(expr, "not");
+                    Node           p    = unaryExpr.getParentNode().get();
+                    unaryExpr.replace(not);
+                } else if (unaryExpr.getOperator() == UnaryExpr.Operator.BITWISE_COMPLEMENT &&
+                           unaryExpr.getExpression() instanceof BigDecimalLiteralExpr) {
+                    throw new UnsupportedOperationException("BigDecimals cannot use bitwise compliment operators");
+                } else {
+                    // No literal-folding special-case applies — recurse so the operand's children
+                    // (NameExpr→ctx, FieldAccessExpr→getter, etc.) still get rewritten.
+                    rewriteNode(unaryExpr.getExpression());
                 }
                 break;
             case "DrlNameExpr":

--- a/src/test/java/org/mvel3/MVELTranspilerTest.java
+++ b/src/test/java/org/mvel3/MVELTranspilerTest.java
@@ -1167,6 +1167,24 @@ class MVELTranspilerTest implements TranspilerTest {
             );
     }
 
+    @Test
+    void testGetterRewriteInsideLogicalNot() {
+        test( "    var p = new Person(\"yoda\");\n" +
+                "    boolean b = !(p.age > 18); \n",
+                "    var p = new Person(\"yoda\");\n" +
+                "    boolean b = !(p.getAge() > 18);\n"
+            );
+    }
+
+    @Test
+    void testGetterRewriteInsideUnaryMinus() {
+        test( "    var p = new Person(\"yoda\");\n" +
+                "    int x = -p.age; \n",
+                "    var p = new Person(\"yoda\");\n" +
+                "    int x = -p.getAge();\n"
+            );
+    }
+
     public static Person createPerson(String name) {
         return new Person(name);
     }


### PR DESCRIPTION
…UnaryExpr recursion

The UnaryExpr case in MVELToJavaRewriter.rewriteNode only recursed into the operand for specific (operator, literal-type) pairs that needed sign-folding or BITWISE_COMPLEMENT-on-BigInteger transformation; for LOGICAL_COMPLEMENT and any non-matching operator/operand combination, the operand was never visited. As a result, child rewrites (FieldAccessExpr → getter, NameExpr → context lookup, ...) were silently skipped under !(...), -prop, ~prop, ++prop, etc. — generated source kept direct field access and failed Java compilation when the field was private.

Restructures the case so the literal-folding paths short-circuit explicitly and a final `else` recurses into the operand. Also fixes the same defect for unary minus/plus on non-literal operands and for BITWISE_COMPLEMENT on non-BigInteger operands.

Adds two regression tests in MVELTranspilerTest:
- testGetterRewriteInsideLogicalNot:  !(p.age > 18)  →  !(p.getAge() > 18)
- testGetterRewriteInsideUnaryMinus:  -p.age         →  -p.getAge()

Refs https://github.com/mvel/mvel/issues/425