### PR TITLE
[mvel-422] PropertyAccessException thrown by compileExpression on cha…

### DIFF
--- a/src/main/java/org/mvel2/compiler/AbstractParser.java
+++ b/src/main/java/org/mvel2/compiler/AbstractParser.java
@@ -2449,8 +2449,12 @@ public class AbstractParser implements Parser, Serializable {
               /**
                * This operator is of the same level precedence.  push to the RHS.
                */
-
-              dStack.push(operator = operator2, nextToken().getReducedValue(ctx, ctx, variableFactory));
+              ASTNode nextToken = nextToken();
+              if (compileMode && !nextToken.isLiteral()) {
+                splitAccumulator.push(nextToken, new OperatorNode(operator2, expr, st, pCtx));
+                return OP_OVERFLOW;
+              }
+              dStack.push(operator = operator2, nextToken.getReducedValue(ctx, ctx, variableFactory));
 
               continue;
             }

--- a/src/test/java/org/mvel2/tests/core/CompileArithmeticIdentifierTest.java
+++ b/src/test/java/org/mvel2/tests/core/CompileArithmeticIdentifierTest.java
@@ -1,0 +1,107 @@
+package org.mvel2.tests.core;
+
+import org.junit.Test;
+import org.mvel2.MVEL;
+import org.mvel2.PropertyAccessException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Regression tests for issue #422: compileExpression must not attempt to
+ * resolve identifiers at compile time during arithmetic constant folding.
+ *
+ * Before the fix, expressions of the form {@code <lit> + <lit> * <lit> * <ident>}
+ * threw PropertyAccessException at compile time because the same-precedence
+ * branch of arithmeticFunctionReduction reduced the trailing identifier
+ * eagerly. Sibling forms with at most one literal multiplication before the
+ * identifier compiled cleanly, exposing the asymmetric handling.
+ */
+public class CompileArithmeticIdentifierTest {
+
+    @Test
+    public void compilesLiteralPlusTwoLiteralMulsThenIdentifier() {
+        // The exact case from issue #422 — must not throw at compile time.
+        MVEL.compileExpression("1 + 1 * 1 * D");
+    }
+
+    @Test
+    public void compilesLiteralPlusTwoNonOneLiteralMulsThenIdentifier() {
+        MVEL.compileExpression("1 + 2 * 3 * D");
+    }
+
+    @Test
+    public void compilesLiteralPlusThreeLiteralMulsThenIdentifier() {
+        MVEL.compileExpression("1 + 1 * 1 * 1 * D");
+    }
+
+    @Test
+    public void compilesPreviouslyWorkingVariants() {
+        // Cases the issue reporter confirmed already compiled — must stay green.
+        MVEL.compileExpression("1 * 1 * D");
+        MVEL.compileExpression("1 + 1 * D");
+        MVEL.compileExpression("1 + D * 1 * 1");
+        MVEL.compileExpression("1 + 1 + 1 * D");
+    }
+
+    @Test
+    public void executesWithIdentifierBound() {
+        Map<String, Object> vars = new HashMap<String, Object>();
+        vars.put("D", 10);
+
+        assertEquals(11, MVEL.executeExpression(MVEL.compileExpression("1 + 1 * 1 * D"), vars));
+        assertEquals(61, MVEL.executeExpression(MVEL.compileExpression("1 + 2 * 3 * D"), vars));
+        assertEquals(11, MVEL.executeExpression(MVEL.compileExpression("1 + 1 * D"), vars));
+        assertEquals(10, MVEL.executeExpression(MVEL.compileExpression("1 * 1 * D"), vars));
+    }
+
+    public static class Bag {
+        public int bar = 7;
+    }
+
+    @Test
+    public void continuesAfterDeferredIdentifierWithLowerPrecedenceOp() {
+        Map<String, Object> vars = new HashMap<String, Object>();
+        vars.put("D", 10);
+        // After the deferred `* D`, a lower-precedence `+ 4` must still parse cleanly.
+        assertEquals(65, MVEL.executeExpression(MVEL.compileExpression("1 + 2 * 3 * D + 4"), vars));
+    }
+
+    @Test
+    public void continuesAfterDeferredIdentifierWithSamePrecedenceOp() {
+        Map<String, Object> vars = new HashMap<String, Object>();
+        vars.put("D", 10);
+        // After the deferred `* D`, a same-precedence `* 4` must still parse cleanly.
+        assertEquals(241, MVEL.executeExpression(MVEL.compileExpression("1 + 2 * 3 * D * 4"), vars));
+    }
+
+    @Test
+    public void deferredNonLiteralMayBeAPropertyAccessor() {
+        Map<String, Object> vars = new HashMap<String, Object>();
+        vars.put("foo", new Bag());
+        assertEquals(43, MVEL.executeExpression(MVEL.compileExpression("1 + 2 * 3 * foo.bar"), vars));
+    }
+
+    @Test
+    public void compileSucceedsButRuntimeStillFailsWhenIdentifierUnbound() {
+        // Compile must not eagerly resolve `D`; runtime must still report it missing.
+        Object compiled = MVEL.compileExpression("1 + 1 * 1 * D");
+        try {
+            MVEL.executeExpression(compiled);
+            fail("Expected PropertyAccessException at runtime for unbound identifier");
+        } catch (PropertyAccessException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void literalOnlyConstantFoldingStillWorks() {
+        // Ensure constant folding for purely literal chains is not regressed.
+        assertEquals(2, MVEL.executeExpression(MVEL.compileExpression("1 + 1 * 1 * 1")));
+        assertEquals(7, MVEL.executeExpression(MVEL.compileExpression("1 + 2 * 3")));
+        assertEquals(13, MVEL.executeExpression(MVEL.compileExpression("1 + 2 * 2 * 3")));
+    }
+}


### PR DESCRIPTION
…ined literal multiplication

Expressions of the form `<lit> + <lit> * <lit> * <ident>` (e.g. `1 + 1 * 1 * D`) threw PropertyAccessException at compile time because the same-precedence branch of AbstractParser.arithmeticFunctionReduction called getReducedValue() on the next token unconditionally, attempting to resolve the trailing identifier against a null variable factory.

Mirror the literal-deferral guard that the higher-precedence branch (lines 2431-2435) already uses: when compileMode is on and the next token is not literal, push it onto splitAccumulator and return OP_OVERFLOW so the caller in ExpressionCompiler.compileReduce can defer the identifier to runtime.

Sibling forms (`1 + 1 * D`, `1 * 1 * D`, `1 + D * 1 * 1`, `1 + 1 + 1 * D`) already compiled because they never hit the unguarded same-precedence path.

- https://github.com/mvel/mvel/issues/422