### PR TITLE
MVELBatchCompiler: keep no-persist mode off global state

### DIFF
--- a/src/main/java/org/mvel3/MVELBatchCompiler.java
+++ b/src/main/java/org/mvel3/MVELBatchCompiler.java
@@ -14,14 +14,19 @@ import com.github.javaparser.ast.CompilationUnit;
 import org.mvel3.javacompiler.KieMemoryCompiler;
 import org.mvel3.lambdaextractor.ArtifactRef;
 import org.mvel3.lambdaextractor.LambdaArtifactLoader;
+import org.mvel3.lambdaextractor.LambdaCatalog;
 import org.mvel3.lambdaextractor.LambdaRuntime;
 import org.mvel3.parser.printer.PrintUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A batch compiler that accumulates lambdas, deduplicates via LambdaRuntime catalog,
- * and compiles all unique ones in a single javac call.
+ * A batch compiler that accumulates lambdas, deduplicates them, and compiles
+ * all unique ones in a single javac call. When constructed with a persistence
+ * directory, dedup goes through the global {@link LambdaRuntime} catalog and
+ * persisted artifacts are reused. When constructed without one (no-persist
+ * mode), dedup uses a batch-local {@link LambdaCatalog} and no global state
+ * is read or mutated.
  */
 public class MVELBatchCompiler {
 
@@ -29,6 +34,10 @@ public class MVELBatchCompiler {
 
     private final ClassManager classManager;
     private final Path persistenceDir; // null = no persistence
+    // In no-persist mode we use a batch-local catalog so dedup and class
+    // renaming still work without touching the global LambdaRuntime catalog.
+    // Null when persistenceDir != null.
+    private final LambdaCatalog localCatalog;
 
     // Accumulated state
     private final Map<String, String> pendingSources = new LinkedHashMap<>(); // fqn -> source
@@ -43,6 +52,7 @@ public class MVELBatchCompiler {
     public MVELBatchCompiler(ClassManager classManager, Path persistenceDir) {
         this.classManager = classManager;
         this.persistenceDir = persistenceDir;
+        this.localCatalog = persistenceDir == null ? new LambdaCatalog() : null;
     }
 
     public ClassManager getClassManager() {
@@ -56,6 +66,28 @@ public class MVELBatchCompiler {
         MVELCompiler compiler = new MVELCompiler();
         CompilationUnit unit = compiler.transpileToCompilationUnit(info);
         String fqn = MVELCompiler.evaluatorFullQualifiedName(unit);
+
+        if (persistenceDir == null) {
+            // No-persist: rename via a batch-local LambdaCatalog so dedup and
+            // unique class names still work, without touching the global
+            // LambdaRuntime catalog or persistence manager.
+            MVELCompiler.LambdaRegistration reg = MVELCompiler.registerAndRename(unit, fqn, localCatalog);
+            int physicalId = reg.physicalId();
+            String newFqn = reg.newFqn();
+
+            HandleState state;
+            if (physicalIdToFqn.containsKey(physicalId)) {
+                newFqn = physicalIdToFqn.get(physicalId);
+                state = HandleState.DEDUP;
+            } else {
+                pendingSources.put(newFqn, PrintUtil.printNode(unit));
+                physicalIdToFqn.put(physicalId, newFqn);
+                state = HandleState.NEW;
+            }
+            LambdaHandle handle = new LambdaHandle(physicalId, newFqn, state);
+            handles.add(handle);
+            return handle;
+        }
 
         // Register with LambdaRuntime catalog and rename class
         MVELCompiler.LambdaRegistration reg = MVELCompiler.registerAndRename(unit, fqn);

--- a/src/main/java/org/mvel3/MVELCompiler.java
+++ b/src/main/java/org/mvel3/MVELCompiler.java
@@ -36,6 +36,7 @@ import com.github.javaparser.resolution.MethodUsage;
 import com.github.javaparser.resolution.declarations.ResolvedReferenceTypeDeclaration;
 import com.github.javaparser.resolution.types.ResolvedType;
 import org.mvel3.javacompiler.KieMemoryCompiler;
+import org.mvel3.lambdaextractor.LambdaCatalog;
 import org.mvel3.lambdaextractor.LambdaKey;
 import org.mvel3.lambdaextractor.ArtifactRef;
 import org.mvel3.lambdaextractor.LambdaArtifactLoader;
@@ -252,9 +253,13 @@ public class MVELCompiler {
     record LambdaRegistration(int physicalId, String newFqn) {}
 
     static LambdaRegistration registerAndRename(CompilationUnit unit, String currentFqn) {
+        return registerAndRename(unit, currentFqn, LambdaRuntime.getInstance().catalog());
+    }
+
+    static LambdaRegistration registerAndRename(CompilationUnit unit, String currentFqn, LambdaCatalog catalog) {
         MethodDeclaration methodDeclaration = unit.findFirst(MethodDeclaration.class).orElseThrow();
         LambdaKey lambdaKey = LambdaUtils.createLambdaKeyFromMethodDeclaration(methodDeclaration);
-        int physicalId = LambdaRuntime.getInstance().catalog().register(lambdaKey).physicalId();
+        int physicalId = catalog.register(lambdaKey).physicalId();
         String oldClassName = currentFqn.substring(currentFqn.lastIndexOf('.') + 1);
         String newClassName = oldClassName + "_" + physicalId;
         ClassOrInterfaceDeclaration classOrInterfaceDeclaration = unit.findFirst(ClassOrInterfaceDeclaration.class).orElseThrow();

--- a/src/test/java/org/mvel3/lambdaextractor/MVELCompilerPersistenceTest.java
+++ b/src/test/java/org/mvel3/lambdaextractor/MVELCompilerPersistenceTest.java
@@ -108,6 +108,70 @@ public class MVELCompilerPersistenceTest {
     }
 
     @Test
+    void M12_batchCompiler_noPersist_doesNotTouchCatalog() {
+        // No-persist batch must keep all state local to the instance and not
+        // touch LambdaRuntime.getInstance().catalog() (no register() calls).
+        ClassManager batchCm = new ClassManager();
+        org.mvel3.MVELBatchCompiler batch = new org.mvel3.MVELBatchCompiler(batchCm); // persistenceDir == null
+
+        CompilerParameters<MyPerson, Void, Boolean> info1 = MVEL.<MyPerson>pojo(MyPerson.class,
+                        Declaration.of("age", int.class))
+                .<Boolean>out(Boolean.class)
+                .expression("age > 20")
+                .imports(Set.of()).classManager(batchCm)
+                .build();
+        CompilerParameters<MyPerson, Void, Boolean> info2 = MVEL.<MyPerson>pojo(MyPerson.class,
+                        Declaration.of("age", int.class))
+                .<Boolean>out(Boolean.class)
+                .expression("age < 10")
+                .imports(Set.of()).classManager(batchCm)
+                .build();
+        batch.add(info1);
+        batch.add(info2);
+        batch.compile(Thread.currentThread().getContextClassLoader());
+
+        // Probe the catalog after the batch: if the batch leaked any
+        // catalog.register(...) calls, the next probe registration would
+        // receive a non-zero logicalId.
+        LambdaKey probe = LambdaUtils.createLambdaKeyFromMethodDeclarationString(
+                "public boolean test(int x) { return x > 0; }");
+        RegistrationResult result = LambdaRuntime.getInstance().catalog().register(probe);
+        assertThat(result.logicalId()).isZero();
+    }
+
+    @Test
+    void M13_batchCompiler_noPersist_ignoresPreviouslyPersistedArtifact() {
+        // Seed: compile lambda X via the single-compiler path with persistence
+        // enabled, so the artifact is now persisted and known to the global
+        // persistence manager.
+        CompilerParameters<MyPerson, Void, Boolean> seed = MVEL.<MyPerson>pojo(MyPerson.class,
+                        Declaration.of("age", int.class))
+                .<Boolean>out(Boolean.class)
+                .expression("age > 20")
+                .imports(Set.of()).classManager(new ClassManager())
+                .build();
+        new MVEL().compilePojoEvaluator(seed);
+
+        int afterSeed = MVELCompiler.compileInvocationCount();
+
+        // Now construct an explicit no-persist batch and ask it to compile the
+        // same lambda. It must compile fresh (i.e., not load from disk via the
+        // global persistenceManager().artifactExists() shortcut).
+        ClassManager batchCm = new ClassManager();
+        org.mvel3.MVELBatchCompiler batch = new org.mvel3.MVELBatchCompiler(batchCm); // persistenceDir == null
+        CompilerParameters<MyPerson, Void, Boolean> info = MVEL.<MyPerson>pojo(MyPerson.class,
+                        Declaration.of("age", int.class))
+                .<Boolean>out(Boolean.class)
+                .expression("age > 20")
+                .imports(Set.of()).classManager(batchCm)
+                .build();
+        batch.add(info);
+        batch.compile(Thread.currentThread().getContextClassLoader());
+
+        assertThat(MVELCompiler.compileInvocationCount()).isEqualTo(afterSeed + 1);
+    }
+
+    @Test
     void M11_runtime_persistenceDisabled_noFileWrites(@org.junit.jupiter.api.io.TempDir Path tmp) {
         String prevEnabled = System.getProperty("mvel3.compiler.lambda.persistence");
         String prevPath = System.getProperty("mvel3.compiler.lambda.persistence.path");


### PR DESCRIPTION
Batch add() always registered with the LambdaRuntime catalog and queried the global persistence manager, regardless of the configured persistenceDir. As a result, no-persist batch mode silently accumulated catalog state and could short-circuit by reusing artifacts persisted by an earlier compiler run.

When persistenceDir is null, dedup and class renaming now go through a batch-local LambdaCatalog; the global catalog and persistence manager are untouched. The persistence-enabled path is unchanged. A shared MVELCompiler.registerAndRename(unit, fqn, LambdaCatalog) overload keeps the rename logic in one place.

Tests:
- M12: after a no-persist batch, a probe catalog.register() returns logicalId 0, proving no global registrations leaked.
- M13: with an artifact persisted on disk for lambda X, a no-persist batch on the same lambda compiles fresh (compileInvocationCount increments) rather than loading from disk.