### PR TITLE
LambdaRegistryStore: convert invalid classFile path to typed exception

### DIFF
--- a/src/main/java/org/mvel3/lambdaextractor/LambdaRegistryStore.java
+++ b/src/main/java/org/mvel3/lambdaextractor/LambdaRegistryStore.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -72,7 +73,14 @@ final class LambdaRegistryStore {
             if (artifacts.containsKey(physicalId)) {
                 throw new InvalidLambdaRegistryException("Duplicate artifact physicalId: " + physicalId);
             }
-            artifacts.put(physicalId, new ArtifactRef(fqn, Path.of(classFile)));
+            Path classFilePath;
+            try {
+                classFilePath = Path.of(classFile);
+            } catch (InvalidPathException e) {
+                throw new InvalidLambdaRegistryException(
+                        "Invalid classFile path for artifact physicalId " + physicalId + ": " + classFile, e);
+            }
+            artifacts.put(physicalId, new ArtifactRef(fqn, classFilePath));
         }
 
         return new LambdaPersistenceSnapshot(

--- a/src/test/java/org/mvel3/lambdaextractor/LambdaRegistryStoreTest.java
+++ b/src/test/java/org/mvel3/lambdaextractor/LambdaRegistryStoreTest.java
@@ -79,6 +79,29 @@ class LambdaRegistryStoreTest {
     }
 
     @Test
+    void M7d_registryStore_invalidClassFilePath_throws(@TempDir Path tmp) throws IOException {
+        // The \\u0000 in the Properties file decodes to a NUL byte, which Path.of()
+        // rejects with the unchecked InvalidPathException on Unix file systems.
+        // The store must convert that into the typed InvalidLambdaRegistryException
+        // so callers can handle malformed metadata uniformly.
+        Path file = tmp.resolve("lambda-registry.dat");
+        Files.writeString(file, String.join("\n",
+                "format.version=2",
+                "catalog.nextPhysicalId=1",
+                "catalog.nextLogicalId=1",
+                "catalog.entry.0.physicalId=0",
+                "catalog.entry.0.methodSignature=public boolean eval(java.lang.Object o)",
+                "catalog.entry.0.normalizedBody={ return o != null; }",
+                "artifact.0.physicalId=0",
+                "artifact.0.fqn=org.mvel3.Gen",
+                "artifact.0.classFile=foo\\u0000bar.class",
+                ""));
+        assertThatThrownBy(() -> new LambdaRegistryStore(file).load())
+                .isInstanceOf(InvalidLambdaRegistryException.class)
+                .hasMessageContaining("classFile");
+    }
+
+    @Test
     void M7c_registryStore_danglingArtifactReference_throws(@TempDir Path tmp) throws IOException {
         Path file = tmp.resolve("lambda-registry.dat");
         Files.writeString(file, String.join("\n",


### PR DESCRIPTION
Path.of(classFile) throws unchecked InvalidPathException when the persisted classFile contains characters the filesystem rejects (e.g. NUL on Unix). That escape broke InvalidLambdaRegistryException's contract — callers expecting the typed exception for malformed registry data instead saw an unchecked path-validation error.

Wrap the conversion and rethrow as InvalidLambdaRegistryException, naming the offending physicalId and the bad value.

Test: M7d_registryStore_invalidClassFilePath_throws.