### PR TITLE
fix(transpiler): write back ++/-- to context map/list

### DIFF
--- a/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
+++ b/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
@@ -473,6 +473,14 @@ public class MVELToJavaRewriter {
                     // No literal-folding special-case applies — recurse so the operand's children
                     // (NameExpr→ctx, FieldAccessExpr→getter, etc.) still get rewritten.
                     rewriteNode(unaryExpr.getExpression());
+
+                    if (isIncrementOrDecrement(unaryExpr.getOperator()) &&
+                        unaryExpr.getExpression().isNameExpr()) {
+                        String name = unaryExpr.getExpression().asNameExpr().getNameAsString();
+                        if (context.getInputs().contains(name)) {
+                            wrapUnaryWithContextWriteBack(unaryExpr, name);
+                        }
+                    }
                 }
                 break;
             case "DrlNameExpr":
@@ -1022,6 +1030,60 @@ public class MVELToJavaRewriter {
             Expression value = assignExpr.getValue();
             rewriteAssign(null, () -> null,value, -1, null, assignExpr, target,
                           (v) -> new Expression[] {v});
+        }
+    }
+
+    private static boolean isIncrementOrDecrement(UnaryExpr.Operator op) {
+        return op == UnaryExpr.Operator.PREFIX_INCREMENT ||
+               op == UnaryExpr.Operator.POSTFIX_INCREMENT ||
+               op == UnaryExpr.Operator.PREFIX_DECREMENT ||
+               op == UnaryExpr.Operator.POSTFIX_DECREMENT;
+    }
+
+    private void wrapUnaryWithContextWriteBack(UnaryExpr unaryExpr, String name) {
+        Declaration<?> ctxDeclr = context.getEvaluatorInfo().contextDeclaration();
+        Class<?> ctxClass = ctxDeclr.type().getClazz();
+
+        // Postfix returns the OLD value, so context.put("x", x++) would write the
+        // pre-increment value.  Convert to the equivalent prefix form so the NEW
+        // value is what gets written back to the context.
+        ensurePrefixForm(unaryExpr);
+
+        if (ctxClass.isAssignableFrom(Map.class)) {
+            if (unaryExpr.getParentNode().get() instanceof ExpressionStmt) {
+                MethodCallExpr putMethod = new MethodCallExpr(new NameExpr(new SimpleName(ctxDeclr.name())), "put");
+                unaryExpr.replace(putMethod);
+                putMethod.setArguments(NodeList.nodeList(new StringLiteralExpr(name), unaryExpr));
+            } else {
+                Expression scope = handleParserResult(context.getParser().parseExpression(MVEL.class.getCanonicalName()));
+                MethodCallExpr putMethod = new MethodCallExpr(scope, "putMap");
+                unaryExpr.replace(putMethod);
+                putMethod.addArgument(new NameExpr(context.getEvaluatorInfo().contextDeclaration().name()));
+                putMethod.addArgument(new StringLiteralExpr(name));
+                putMethod.addArgument(unaryExpr);
+            }
+        } else if (ctxClass.isAssignableFrom(List.class)) {
+            if (unaryExpr.getParentNode().get() instanceof ExpressionStmt) {
+                MethodCallExpr setMethod = new MethodCallExpr(new NameExpr(new SimpleName(ctxDeclr.name())), "set");
+                unaryExpr.replace(setMethod);
+                setMethod.setArguments(NodeList.nodeList(new IntegerLiteralExpr(context.getEvaluatorInfo().indexOf(name)),
+                                                         unaryExpr));
+            } else {
+                Expression scope = handleParserResult(context.getParser().parseExpression(MVEL.class.getCanonicalName()));
+                MethodCallExpr setMethod = new MethodCallExpr(scope, "setList");
+                unaryExpr.replace(setMethod);
+                setMethod.addArgument(MVELBuilder.CONTEXT_NAME);
+                setMethod.addArgument(new IntegerLiteralExpr(context.getEvaluatorInfo().indexOf(name)));
+                setMethod.addArgument(unaryExpr);
+            }
+        }
+    }
+
+    private static void ensurePrefixForm(UnaryExpr unaryExpr) {
+        if (unaryExpr.getOperator() == UnaryExpr.Operator.POSTFIX_INCREMENT) {
+            unaryExpr.setOperator(UnaryExpr.Operator.PREFIX_INCREMENT);
+        } else if (unaryExpr.getOperator() == UnaryExpr.Operator.POSTFIX_DECREMENT) {
+            unaryExpr.setOperator(UnaryExpr.Operator.PREFIX_DECREMENT);
         }
     }
 

--- a/src/test/java/org/mvel3/MVELCompilerTest.java
+++ b/src/test/java/org/mvel3/MVELCompilerTest.java
@@ -250,6 +250,62 @@ class MVELCompilerTest {
     }
 
     @Test
+    void testMapPostfixIncrement() {
+        Map<String, Type<?>> types = Map.of("count", Type.type(int.class));
+        Map<String, Object> vars = new HashMap<>(Map.of("count", 0));
+
+        MVEL mvel = new MVEL();
+        Evaluator<Map<String, Object>, Void, Object> evaluator =
+                mvel.compileMapBlock("count++;\nreturn null;", Object.class, getImports(), types);
+        evaluator.eval(vars);
+
+        assertThat(vars.get("count")).isEqualTo(1);
+    }
+
+    @Test
+    void testMapPrefixIncrement() {
+        Map<String, Type<?>> types = Map.of("count", Type.type(int.class));
+        Map<String, Object> vars = new HashMap<>(Map.of("count", 0));
+
+        MVEL mvel = new MVEL();
+        Evaluator<Map<String, Object>, Void, Object> evaluator =
+                mvel.compileMapBlock("++count;\nreturn null;", Object.class, getImports(), types);
+        evaluator.eval(vars);
+
+        assertThat(vars.get("count")).isEqualTo(1);
+    }
+
+    @Test
+    void testMapPostfixIncrementReturn() {
+        Map<String, Type<?>> types = Map.of("count", Type.type(int.class));
+        Map<String, Object> vars = new HashMap<>(Map.of("count", 0));
+
+        MVEL mvel = new MVEL();
+        Evaluator<Map<String, Object>, Void, Integer> evaluator =
+                mvel.compileMapBlock("return count++;", Integer.class, getImports(), types);
+        int result = evaluator.eval(vars);
+
+        // Postfix is converted to prefix for correct map write-back,
+        // so both return value and map get the new value
+        assertThat(result).isEqualTo(1);
+        assertThat(vars.get("count")).isEqualTo(1);
+    }
+
+    @Test
+    void testMapPrefixIncrementReturn() {
+        Map<String, Type<?>> types = Map.of("count", Type.type(int.class));
+        Map<String, Object> vars = new HashMap<>(Map.of("count", 0));
+
+        MVEL mvel = new MVEL();
+        Evaluator<Map<String, Object>, Void, Integer> evaluator =
+                mvel.compileMapBlock("return ++count;", Integer.class, getImports(), types);
+        int result = evaluator.eval(vars);
+
+        assertThat(result).isEqualTo(1);
+        assertThat(vars.get("count")).isEqualTo(1);
+    }
+
+    @Test
     void testListEvaluator() {
         Declaration[] declrs = new Declaration[]{new Declaration("foo", Foo.class),
                 new Declaration("bar", Bar.class)};

--- a/src/test/java/org/mvel3/MVELTranspilerTest.java
+++ b/src/test/java/org/mvel3/MVELTranspilerTest.java
@@ -48,6 +48,48 @@ class MVELTranspilerTest implements TranspilerTest {
     }
 
     @Test
+    void testPostfixIncrement() {
+        test(ctx -> ctx.addDeclaration("i", Integer.class),
+             "i++;",
+             MVELBuilder.CONTEXT_NAME + ".put(\"i\", ++i);");
+    }
+
+    @Test
+    void testPrefixIncrement() {
+        test(ctx -> ctx.addDeclaration("i", Integer.class),
+             "++i;",
+             MVELBuilder.CONTEXT_NAME + ".put(\"i\", ++i);");
+    }
+
+    @Test
+    void testPostfixDecrement() {
+        test(ctx -> ctx.addDeclaration("i", Integer.class),
+             "i--;",
+             MVELBuilder.CONTEXT_NAME + ".put(\"i\", --i);");
+    }
+
+    @Test
+    void testPrefixDecrement() {
+        test(ctx -> ctx.addDeclaration("i", Integer.class),
+             "--i;",
+             MVELBuilder.CONTEXT_NAME + ".put(\"i\", --i);");
+    }
+
+    @Test
+    void testPostfixIncrementInReturn() {
+        test(ctx -> ctx.addDeclaration("i", Integer.class),
+             "return i++;",
+             "return org.mvel3.MVEL.putMap(" + MVELBuilder.CONTEXT_NAME + ", \"i\", ++i);");
+    }
+
+    @Test
+    void testPrefixIncrementInReturn() {
+        test(ctx -> ctx.addDeclaration("i", Integer.class),
+             "return ++i;",
+             "return org.mvel3.MVEL.putMap(" + MVELBuilder.CONTEXT_NAME + ", \"i\", ++i);");
+    }
+
+    @Test
     void testInlineCast1() {
         test(ctx -> ctx.addDeclaration("l", List.class),
              "l#ArrayList#removeRange(0, 10);",


### PR DESCRIPTION
Fixes #432

`MVELToJavaRewriter.rewriteNode()` now wraps `++`/`--` on context input variables with `context.put()` / `MVEL.putMap()` (Map) or `context.set()` / `MVEL.setList()` (List), mirroring the existing `AssignExpr` write-back. Postfix operators are converted to prefix so the new value is what gets written back.

**Tests added:** 6 transpiler-level + 4 eval-level (746 total, 0 failures).