### PR TITLE
fix(transpiler): rewrite == / != to Objects.equals() for reference types

### DIFF
--- a/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
+++ b/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
@@ -1279,9 +1279,9 @@ public class MVELToJavaRewriter {
             Node parent = binExpr.getParentNode().get();
 
             nodeMap.remove(binExpr);
-            Expression overloaded = rewrite(types);
-            if (overloaded != null) {
-                binExpr.replace(overloaded);
+            Expression rewritten = rewrite(types);
+            if (rewritten != null) {
+                binExpr.replace(rewritten);
             }
 
             if (binExpr != rootBinaryExpr) {
@@ -1329,8 +1329,51 @@ public class MVELToJavaRewriter {
             binExprTypes.binaryExpr.setLeft(left);
         }
 
-        Expression overloaded = overloader.overload(leftType, left, right, binExprTypes.binaryExpr.getOperator());
-        return overloaded;
+        Expression rewritten = overloader.overload(leftType, left, right, binExprTypes.binaryExpr.getOperator());
+        if (rewritten == null) {
+            rewritten = rewriteReferenceEquality(binExprTypes);
+        }
+        return rewritten;
+    }
+
+    private Expression rewriteReferenceEquality(BinaryExprTypes binExprTypes) {
+        BinaryExpr.Operator op = binExprTypes.getBinaryExpr().getOperator();
+        if (op != BinaryExpr.Operator.EQUALS && op != BinaryExpr.Operator.NOT_EQUALS) {
+            return null;
+        }
+
+        ResolvedType leftType = binExprTypes.leftType;
+        ResolvedType rightType = binExprTypes.rightType;
+
+        if ((leftType == null || leftType.isPrimitive()) && (rightType == null || rightType.isPrimitive())) {
+            return null;
+        }
+
+        Expression left = binExprTypes.left;
+        Expression right = binExprTypes.right;
+
+        if (left instanceof NullLiteralExpr || right instanceof NullLiteralExpr) {
+            return null;
+        }
+
+        if (isEnum(leftType) || isEnum(rightType)) {
+            return null;
+        }
+
+        MethodCallExpr equalsCall = new MethodCallExpr(
+                new NameExpr("java.util.Objects"), "equals",
+                new NodeList<>(left.clone(), right.clone()));
+
+        if (op == BinaryExpr.Operator.NOT_EQUALS) {
+            return new UnaryExpr(equalsCall, UnaryExpr.Operator.LOGICAL_COMPLEMENT);
+        }
+        return equalsCall;
+    }
+
+    private boolean isEnum(ResolvedType type) {
+        return type != null && type.isReferenceType()
+                && type.asReferenceType().getTypeDeclaration().isPresent()
+                && type.asReferenceType().getTypeDeclaration().get().isEnum();
     }
 
     public static boolean isAssignableBy(ResolvedType target, ResolvedType source) {

--- a/src/test/java/org/mvel3/ConstraintTranspilerTest.java
+++ b/src/test/java/org/mvel3/ConstraintTranspilerTest.java
@@ -143,6 +143,60 @@ class ConstraintTranspilerTest implements TranspilerTest {
                        "{var x = _this.getParent().getSalary().compareTo(BigDecimal.valueOf(90)) != 0;}");
     }
 
+    @Test
+    void testStringEquality() {
+        testExpression(c -> c.withDeclaration(Declaration.of("_this", Person.class)), "{var x = name == \"John\";}",
+                       "{var x = java.util.Objects.equals(_this.getName(), \"John\");}");
+    }
+
+    @Test
+    void testStringNonEquality() {
+        testExpression(c -> c.withDeclaration(Declaration.of("_this", Person.class)), "{var x = name != \"John\";}",
+                       "{var x = !java.util.Objects.equals(_this.getName(), \"John\");}");
+    }
+
+    @Test
+    void testStringEqualityWithBoundVariable() {
+        testExpression(c -> {
+            c.withDeclaration(Declaration.of("_this", Person.class));
+            c.addDeclaration("$n", String.class);
+        }, "{var x = name == $n;}",
+           "{var x = java.util.Objects.equals(_this.getName(), $n);}");
+    }
+
+    @Test
+    void testNestedPropertyStringEquality() {
+        testExpression(c -> c.withDeclaration(Declaration.of("_this", Person.class)), "{var x = parent.name == \"John\";}",
+                       "{var x = java.util.Objects.equals(_this.getParent().getName(), \"John\");}");
+    }
+
+    @Test
+    void testObjectEquality() {
+        testExpression(c -> {
+            c.withDeclaration(Declaration.of("_this", Person.class));
+            c.addDeclaration("$p", Person.class);
+        }, "{var x = parent == $p;}",
+           "{var x = java.util.Objects.equals(_this.getParent(), $p);}");
+    }
+
+    @Test
+    void testEnumEqualityUnchanged() {
+        testExpression(c -> c.withDeclaration(Declaration.of("_this", Person.class)), "{var x = gender == Gender.MALE;}",
+                       "{var x = _this.getGender() == _this.getGender().MALE;}");
+    }
+
+    @Test
+    void testNullComparisonUnchanged() {
+        testExpression(c -> c.withDeclaration(Declaration.of("_this", Person.class)), "{var x = name == null;}",
+                       "{var x = _this.getName() == null;}");
+    }
+
+    @Test
+    void testPrimitiveEqualityUnchanged() {
+        testExpression(c -> c.withDeclaration(Declaration.of("_this", Person.class)), "{var x = age == 30;}",
+                       "{var x = _this.getAge() == 30;}");
+    }
+
     public <K, R> void testExpression(Consumer<MVELBuilder<Map<String, Object>, Void, Object>> testFunction,
                                String inputExpression,
                                String expectedResult,


### PR DESCRIPTION
## Summary

- MVEL3's transpiler was generating Java `==` (reference equality) for `==`/`!=` on all reference types except BigDecimal/BigInteger, violating MVEL's semantic contract that `==` means value equality
- Add `rewriteReferenceEquality()` fallback in `MVELToJavaRewriter` that generates `java.util.Objects.equals(left, right)` for `==` and `!java.util.Objects.equals(left, right)` for `!=`
- Exclusions: primitives, enums, and null comparisons stay as Java `==`

## Test plan
- [x] 8 new tests in `ConstraintTranspilerTest`: String `==`/`!=`, bound variable, nested property, Object equality, enum/null/primitive exclusions
- [x] All 754 existing MVEL3 tests pass (0 regressions)
- [x] All 279 drlx-parser tests pass with updated MVEL3

🤖 Generated with [Claude Code](https://claude.com/claude-code)