### PR TITLE
Add CompactWithExpression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <asm.version>9.7.1</asm.version>
         <antlr4.version>4.13.2</antlr4.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
-        <javaparser.version>3.25.5-mvel3-1</javaparser.version>
+        <javaparser.version>3.25.5-mvel3-SNAPSHOT</javaparser.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <assertj-core.version>3.27.3</assertj-core.version>
         <drools-compiler.version>10.1.0</drools-compiler.version>

--- a/src/main/antlr4/org/mvel3/parser/antlr4/Mvel3Parser.g4
+++ b/src/main/antlr4/org/mvel3/parser/antlr4/Mvel3Parser.g4
@@ -76,6 +76,9 @@ expression
     | mapCreationLiteral                                            #MapCreationLiteralExpression
     | expression '[' expression ']'                                 #SquareBracketExpression
 
+    // MVEL compact with expression: t{prop = val, ...}
+    | identifier '{' compactWithAssignment (',' compactWithAssignment)* '}'  #CompactWithExpression
+
     // Mvel 3
     | expression HASH typeType HASH (identifier arguments? | '[' expression ']')? #InlineCastExpression
 
@@ -188,6 +191,10 @@ withStatement
     : WITH LPAREN identifier RPAREN LBRACE (statement)* RBRACE
     ;
 
+// MVEL-specific compact with expression: t{prop = val, ...}
+compactWithAssignment
+    : identifier '=' expression
+    ;
 
 // Override block without any changes. Just for ANTLR plugin conveinience. We may remove this later.
 block

--- a/src/main/java/org/mvel3/parser/antlr4/Mvel3ToJavaParserVisitor.java
+++ b/src/main/java/org/mvel3/parser/antlr4/Mvel3ToJavaParserVisitor.java
@@ -17,8 +17,13 @@
 package org.mvel3.parser.antlr4;
 
 import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AssignExpr;
+import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import org.mvel3.parser.ast.expr.CompactWithExpression;
+import org.mvel3.parser.antlr4.mveltojavaparser.TokenRangeConverter;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -330,6 +335,24 @@ public class Mvel3ToJavaParserVisitor extends Mvel3ParserBaseVisitor<Node> {
     @Override
     public Node visitWithStatement(Mvel3Parser.WithStatementContext ctx) {
         return StatementConverter.convertWithStatement(ctx, this);
+    }
+
+    @Override
+    public Node visitCompactWithExpression(Mvel3Parser.CompactWithExpressionContext ctx) {
+        String targetName = ctx.identifier().getText();
+        NameExpr target = new NameExpr(targetName);
+        target.setTokenRange(TokenRangeConverter.createTokenRange(ctx));
+
+        NodeList<AssignExpr> assignments = new NodeList<>();
+        for (Mvel3Parser.CompactWithAssignmentContext assignCtx : ctx.compactWithAssignment()) {
+            String propName = assignCtx.identifier().getText();
+            NameExpr propTarget = new NameExpr(propName);
+            propTarget.setTokenRange(TokenRangeConverter.createTokenRange(assignCtx));
+            Expression value = (Expression) visit(assignCtx.expression());
+            assignments.add(new AssignExpr(propTarget, value, AssignExpr.Operator.ASSIGN));
+        }
+
+        return new CompactWithExpression(TokenRangeConverter.createTokenRange(ctx), target, assignments);
     }
 
     @Override

--- a/src/main/java/org/mvel3/parser/printer/MVELPrintVisitor.java
+++ b/src/main/java/org/mvel3/parser/printer/MVELPrintVisitor.java
@@ -82,6 +82,7 @@ import org.mvel3.parser.ast.expr.TemporalChunkExpr;
 import org.mvel3.parser.ast.expr.TemporalLiteralChunkExpr;
 import org.mvel3.parser.ast.expr.TemporalLiteralExpr;
 import org.mvel3.parser.ast.expr.TemporalLiteralInfiniteChunkExpr;
+import org.mvel3.parser.ast.expr.CompactWithExpression;
 import org.mvel3.parser.ast.expr.WithStatement;
 import org.mvel3.parser.ast.visitor.DrlVoidVisitor;
 
@@ -376,6 +377,23 @@ public class MVELPrintVisitor extends DefaultPrettyPrinterVisitor implements Drl
     public void visit(WithStatement withExpression, Void arg) {
         printer.print("with (");
         visitContextStatement(withExpression, arg);
+    }
+
+    @Override
+    public void visit(CompactWithExpression compactWith, Void arg) {
+        compactWith.getTarget().accept(this, arg);
+        printer.print("{");
+        NodeList<AssignExpr> assignments = compactWith.getAssignments();
+        for (int i = 0; i < assignments.size(); i++) {
+            AssignExpr a = assignments.get(i);
+            printer.print(PrintUtil.printNode(a.getTarget()));
+            printer.print(" = ");
+            printer.print(PrintUtil.printNode(a.getValue()));
+            if (i < assignments.size() - 1) {
+                printer.print(", ");
+            }
+        }
+        printer.print("}");
     }
 
     public <T extends AbstractContextStatement, R extends Expression> void visitContextStatement(AbstractContextStatement<T, R> contextExpression, Void arg) {

--- a/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
+++ b/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
@@ -429,22 +429,13 @@ public class MVELToJavaRewriter {
                 isModifyWithContext = true;
             case "WithStatement" : {
                 AbstractContextStatement modifyStmt = (AbstractContextStatement) node;
-                NameExpr                 nameExpr   = (NameExpr) modifyStmt.getTarget();
-                withContextName = nameExpr;
-                withContextType = nameExpr.calculateResolvedType();
-
-                // create a block to hold the rewritten statements to repalce the modify block
+                NameExpr nameExpr = (NameExpr) modifyStmt.getTarget();
                 BlockStmt blockStmt = new BlockStmt();
                 modifyStmt.replace(blockStmt);
                 modifyStmt.getTarget().setParentNode(blockStmt);
-                modifyStmt.getExpressions().forEach(n -> blockStmt.addStatement((Statement) n));
-                blockStmt.getStatements().forEach( n -> rewriteNode(n));
-                if (isModifyWithContext) {
-                    blockStmt.addStatement(new MethodCallExpr("update", new NameExpr(withContextName.getNameAsString())));
-                }
-
-                withContextName = null;
-                withContextType = null;
+                expandContextBlock(nameExpr,
+                        modifyStmt.getExpressions().stream().map(n -> (Statement) n).toList(),
+                        blockStmt, isModifyWithContext);
                 break;
             }
             case "UnaryExpr":
@@ -902,6 +893,20 @@ public class MVELToJavaRewriter {
         }
 
         return expr;
+    }
+
+    private void expandContextBlock(NameExpr contextName, List<? extends Statement> statements,
+                                    BlockStmt outputBlock, boolean addUpdateCall) {
+        withContextName = contextName;
+        withContextType = contextName.calculateResolvedType();
+        statements.forEach(s -> outputBlock.addStatement(s));
+        outputBlock.getStatements().forEach(this::rewriteNode);
+        if (addUpdateCall) {
+            outputBlock.addStatement(
+                    new MethodCallExpr("update", new NameExpr(contextName.getNameAsString())));
+        }
+        withContextName = null;
+        withContextType = null;
     }
 
     private void processAssignExpr(AssignExpr node) {

--- a/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
+++ b/src/main/java/org/mvel3/transpiler/MVELToJavaRewriter.java
@@ -51,6 +51,7 @@ import com.github.javaparser.utils.Pair;
 import org.mvel3.MVELBuilder;
 import org.mvel3.MVEL;
 import org.mvel3.parser.ast.expr.AbstractContextStatement;
+import org.mvel3.parser.ast.expr.CompactWithExpression;
 import org.mvel3.parser.ast.expr.BigDecimalLiteralExpr;
 import org.mvel3.parser.ast.expr.BigIntegerLiteralExpr;
 import org.mvel3.parser.ast.expr.InlineCastExpr;
@@ -436,6 +437,38 @@ public class MVELToJavaRewriter {
                 expandContextBlock(nameExpr,
                         modifyStmt.getExpressions().stream().map(n -> (Statement) n).toList(),
                         blockStmt, isModifyWithContext);
+                break;
+            }
+            case "CompactWithExpression" : {
+                CompactWithExpression compactWith = (CompactWithExpression) node;
+                NameExpr targetName = compactWith.getTarget();
+
+                List<Statement> expandedStmts = new ArrayList<>();
+                for (AssignExpr assignment : compactWith.getAssignments()) {
+                    expandedStmts.add(new ExpressionStmt(assignment));
+                }
+
+                Node parent = compactWith.getParentNode().orElse(null);
+                if (parent instanceof ExpressionStmt) {
+                    BlockStmt blockStmt = new BlockStmt();
+                    parent.replace(blockStmt);
+                    targetName.setParentNode(blockStmt);
+                    expandContextBlock(targetName, expandedStmts, blockStmt, false);
+                } else {
+                    Node current = parent;
+                    while (current != null && !(current instanceof ExpressionStmt)) {
+                        current = current.getParentNode().orElse(null);
+                    }
+                    if (current instanceof ExpressionStmt enclosingStmt) {
+                        BlockStmt blockStmt = new BlockStmt();
+                        enclosingStmt.replace(blockStmt);
+                        targetName.setParentNode(blockStmt);
+                        expandContextBlock(targetName, expandedStmts, blockStmt, false);
+                        compactWith.replace(new NameExpr(targetName.getNameAsString()));
+                        blockStmt.addStatement(enclosingStmt);
+                        rewriteNode(enclosingStmt);
+                    }
+                }
                 break;
             }
             case "UnaryExpr":

--- a/src/test/java/org/mvel3/MVELTranspilerTest.java
+++ b/src/test/java/org/mvel3/MVELTranspilerTest.java
@@ -1827,6 +1827,33 @@ class MVELTranspilerTest implements TranspilerTest {
              result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("foo"));
     }
 
+    @Test
+    void testCompactWithStandalone() {
+        test(ctx -> ctx.addDeclaration("foo", Foo.class),
+             "foo{countTest = 5};",
+             "{ foo.setCountTest(5); }",
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("foo"));
+    }
+
+    @Test
+    void testCompactWithStandaloneMultipleAssignments() {
+        test(ctx -> ctx.addDeclaration("$p", Person.class),
+             "$p{name = \"Luca\", age = 35};",
+             "{ $p.setName(\"Luca\"); $p.setAge(35); }",
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p"));
+    }
+
+    @Test
+    void testCompactWithInlineMethodArg() {
+        test(ctx -> {
+                 ctx.addDeclaration("$p", Person.class);
+                 ctx.addDeclaration("list", java.util.List.class);
+             },
+             "list.add($p{name = \"Luca\", age = 35});",
+             "{ $p.setName(\"Luca\"); $p.setAge(35); list.add($p); }",
+             result -> assertThat(allUsedBindings(result)).containsExactlyInAnyOrder("$p", "list"));
+    }
+
     @Test @Disabled("Not yet supporing Method's with expressions, only variables")
     void testUncompiledMethod() {
         test("modify( (List)$toEdit.get(0) ){ setEnabled( true ) }",

--- a/src/test/java/org/mvel3/MVELTranspilerTest.java
+++ b/src/test/java/org/mvel3/MVELTranspilerTest.java
@@ -1844,6 +1844,23 @@ class MVELTranspilerTest implements TranspilerTest {
     }
 
     @Test
+    void testCompactWithStandaloneEval() {
+        Person person = new Person("John");
+        person.setAge(20);
+        java.util.Set<String> imports = new java.util.HashSet<>();
+        imports.add(Person.class.getCanonicalName());
+        Evaluator<Map<String, Object>, Void, String> evaluator =
+                new MVEL().compileMapBlock("$p{name = \"Luca\", age = 35};\n return null;",
+                        String.class, imports,
+                        Map.of("$p", Type.type(Person.class)));
+        Map<String, Object> vars = new java.util.HashMap<>();
+        vars.put("$p", person);
+        evaluator.eval(vars);
+        assertThat(person.getName()).isEqualTo("Luca");
+        assertThat(person.getAge()).isEqualTo(35);
+    }
+
+    @Test
     void testCompactWithInlineMethodArg() {
         test(ctx -> {
                  ctx.addDeclaration("$p", Person.class);

--- a/src/test/java/org/mvel3/parser/antlr4/Antlr4MvelParserTest.java
+++ b/src/test/java/org/mvel3/parser/antlr4/Antlr4MvelParserTest.java
@@ -31,11 +31,18 @@ import static org.mvel3.parser.antlr4.ParserTestUtil.getBinaryOperatorExpression
 import static org.mvel3.parser.antlr4.ParserTestUtil.getTemporalLiteralContext;
 import static org.mvel3.parser.printer.PrintUtil.printNode;
 
+import com.github.javaparser.ParseResult;
+import com.github.javaparser.ast.stmt.BlockStmt;
+
 /**
  * Tests for the MVEL parser using ANTLR4.
  * Assertions are based on the generated Antlr AST.
  */
 class Antlr4MvelParserTest {
+
+    private static String newLine() {
+        return System.lineSeparator();
+    }
 
     @Test
     void testParseSimpleExpr() {
@@ -193,5 +200,31 @@ class Antlr4MvelParserTest {
         assertThat(temporalLiteralChunkContext0.MINUTE_LITERAL().getText()).isEqualTo("1m");
         Mvel3Parser.TemporalLiteralChunkContext temporalLiteralChunkContext1 = temporalLiteralContext.temporalLiteralChunk(1);
         assertThat(temporalLiteralChunkContext1.SECOND_LITERAL().getText()).isEqualTo("5s");
+    }
+
+    @Test
+    void testCompactWithExpression() {
+        String expr = "{ t{status = RECEIVED, timestamp = new Date()}; }";
+        Antlr4MvelParser parser = new Antlr4MvelParser();
+        ParseResult<BlockStmt> result = parser.parseBlock(expr);
+        assertThat(result.isSuccessful()).isTrue();
+        BlockStmt block = result.getResult().get();
+        assertThat(printNode(block)).isEqualToIgnoringWhitespace(
+                "{" + newLine() +
+                "    t{status = RECEIVED, timestamp = new Date()};" + newLine() +
+                "}");
+    }
+
+    @Test
+    void testCompactWithExpressionSingleAssignment() {
+        String expr = "{ t{status = RECEIVED}; }";
+        Antlr4MvelParser parser = new Antlr4MvelParser();
+        ParseResult<BlockStmt> result = parser.parseBlock(expr);
+        assertThat(result.isSuccessful()).isTrue();
+        BlockStmt block = result.getResult().get();
+        assertThat(printNode(block)).isEqualToIgnoringWhitespace(
+                "{" + newLine() +
+                "    t{status = RECEIVED};" + newLine() +
+                "}");
     }
 }


### PR DESCRIPTION
‘with’ style blocks
{} is used for a series of  setters in a block. The {} block returns the subject, allowing it to be easily used with ‘update’ or other similar methods.

```java
t{status = RECEIVED,
  timestamp = new Date()};
```
As the {} block returns the subject, it's Expression rather than Statement, so create a new AST `CompactWithExpression` instead of re-using `WithStatement`